### PR TITLE
fix(update): in-app updater finds new pre-releases (/releases endpoint)

### DIFF
--- a/src/Wavee.AudioHost/NativeDeps/NativeLibraryProvisioner.cs
+++ b/src/Wavee.AudioHost/NativeDeps/NativeLibraryProvisioner.cs
@@ -88,8 +88,11 @@ internal sealed class NativeLibraryProvisioner
             try { File.Delete(cachePath); } catch { /* will fail later if the file is locked */ }
         }
 
-        // 4-7. Download + extract + verify, with one retry on hash mismatch.
-        const int maxAttempts = 2;
+        // 4-7. Download + extract + verify, retrying transient failures (network / HTTP / hash
+        // mismatch). First-run provisioning is the only window where this runs, and a single
+        // transient blip here means the audio engine never comes up at all (issue #4), so a few
+        // backed-off retries are worth it.
+        const int maxAttempts = 3;
         Exception? lastException = null;
         string? lastReason = null;
 
@@ -109,12 +112,18 @@ internal sealed class NativeLibraryProvisioner
             lastException = ex;
             lastReason = reason;
 
-            // Only retry on integrity-mismatch (deterministic enough that one more pull might help
-            // if the CDN served a stale response). Network errors get one attempt.
-            if (attempt < maxAttempts && reason == FailureReasons.IntegrityMismatch)
+            // Retry transient failures: an integrity mismatch (CDN served a stale/partial response)
+            // or a network/HTTP error (a first-run blip, a slow link, a momentarily blocked host).
+            // Layout/extract/move errors are deterministic and not worth retrying.
+            var transient = reason is FailureReasons.IntegrityMismatch
+                or FailureReasons.NetworkError
+                or FailureReasons.HttpError;
+            if (attempt < maxAttempts && transient)
             {
-                _logger.LogWarning("Retrying native dependency download after integrity failure (attempt {N}/{Max})",
-                    attempt + 1, maxAttempts);
+                _logger.LogWarning("Retrying native dependency download after transient failure '{Reason}' (attempt {N}/{Max})",
+                    reason, attempt + 1, maxAttempts);
+                try { await Task.Delay(TimeSpan.FromSeconds(2 * attempt), ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { break; }
                 continue;
             }
             break;

--- a/src/Wavee.UI.WinUI/Controls/Cards/AnimatedHeroBackground.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Cards/AnimatedHeroBackground.xaml.cs
@@ -51,6 +51,11 @@ public sealed partial class AnimatedHeroBackground : UserControl, INavCacheSurfa
     // the DP, which throws when accessed off the dispatcher.
     private float _clipRadius;
     private bool _navCacheReleased;
+    private bool _renderFailed;
+    // Cached on the UI thread (construction) so the render-thread OnDraw failure path can
+    // marshal back without touching DependencyObject.DispatcherQueue off-thread (which throws).
+    private readonly Microsoft.UI.Dispatching.DispatcherQueue? _dispatcher =
+        Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 
     public Color PrimaryColor
     {
@@ -196,39 +201,62 @@ public sealed partial class AnimatedHeroBackground : UserControl, INavCacheSurfa
 
     private void OnDraw(ICanvasAnimatedControl sender, CanvasAnimatedDrawEventArgs args)
     {
-        var width = (int)sender.ConvertDipsToPixels((float)sender.Size.Width, CanvasDpiRounding.Round);
-        var height = (int)sender.ConvertDipsToPixels((float)sender.Size.Height, CanvasDpiRounding.Round);
-        if (width <= 0 || height <= 0)
+        if (_renderFailed)
             return;
 
-        _effect.ConstantBuffer = new MeshGradientShader(
-            (float)args.Timing.TotalTime.TotalSeconds,
-            new int2(width, height),
-            _primary,
-            _accent);
-
-        // Clip the shader output to the rounded card shape inside Win2D itself.
-        // SwapChainPanel content (CanvasAnimatedControl's swap chain) does NOT honour
-        // composition clips applied to ancestors OR to its own visual — the swap chain
-        // is presented separately by DComp on top of the WinUI tree. The only reliable
-        // way to round the shader is to draw it inside a CanvasDrawingSession layer
-        // bound by a rounded-rect CanvasGeometry, so the back buffer itself is rounded
-        // (corners stay transparent from ClearColor=Transparent and blend with the
-        // page background). _clipRadius is cached on the UI thread — reading the DP
-        // from this render-thread callback would throw.
-        var radius = _clipRadius;
-        if (radius > 0)
+        try
         {
-            var rect = new Rect(0, 0, sender.Size.Width, sender.Size.Height);
-            using var clipGeometry = CanvasGeometry.CreateRoundedRectangle(args.DrawingSession, rect, radius, radius);
-            using (args.DrawingSession.CreateLayer(1f, clipGeometry))
+            var width = (int)sender.ConvertDipsToPixels((float)sender.Size.Width, CanvasDpiRounding.Round);
+            var height = (int)sender.ConvertDipsToPixels((float)sender.Size.Height, CanvasDpiRounding.Round);
+            if (width <= 0 || height <= 0)
+                return;
+
+            _effect.ConstantBuffer = new MeshGradientShader(
+                (float)args.Timing.TotalTime.TotalSeconds,
+                new int2(width, height),
+                _primary,
+                _accent);
+
+            // Clip the shader output to the rounded card shape inside Win2D itself.
+            // SwapChainPanel content (CanvasAnimatedControl's swap chain) does NOT honour
+            // composition clips applied to ancestors OR to its own visual — the swap chain
+            // is presented separately by DComp on top of the WinUI tree. The only reliable
+            // way to round the shader is to draw it inside a CanvasDrawingSession layer
+            // bound by a rounded-rect CanvasGeometry, so the back buffer itself is rounded
+            // (corners stay transparent from ClearColor=Transparent and blend with the
+            // page background). _clipRadius is cached on the UI thread — reading the DP
+            // from this render-thread callback would throw.
+            var radius = _clipRadius;
+            if (radius > 0)
+            {
+                var rect = new Rect(0, 0, sender.Size.Width, sender.Size.Height);
+                using var clipGeometry = CanvasGeometry.CreateRoundedRectangle(args.DrawingSession, rect, radius, radius);
+                using (args.DrawingSession.CreateLayer(1f, clipGeometry))
+                {
+                    args.DrawingSession.DrawImage(_effect);
+                }
+            }
+            else
             {
                 args.DrawingSession.DrawImage(_effect);
             }
         }
-        else
+        catch (System.Exception ex)
         {
-            args.DrawingSession.DrawImage(_effect);
+            // No usable graphics device / shader pipeline (GPU-less VM, RDP, driver fault).
+            // Disable the animated layer and fall back to whatever the consumer paints behind
+            // it, rather than letting the failure escape the Win2D render thread and crash the
+            // process with a stowed exception. One-shot: stop the loop and collapse the surface.
+            _renderFailed = true;
+            System.Diagnostics.Debug.WriteLine($"[AnimatedHeroBackground] shader render failed, disabling: {ex}");
+            _dispatcher?.TryEnqueue(() =>
+            {
+                if (PART_Canvas is { } canvas)
+                {
+                    canvas.Paused = true;
+                    canvas.Visibility = Visibility.Collapsed;
+                }
+            });
         }
     }
 

--- a/src/Wavee.UI.WinUI/Controls/Notifications/NotificationToast.xaml
+++ b/src/Wavee.UI.WinUI/Controls/Notifications/NotificationToast.xaml
@@ -69,13 +69,22 @@
                            Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                            FontSize="14"/>
 
-                <Button x:Name="ActionButton"
-                        Grid.Column="2"
-                        VerticalAlignment="Center"
-                        MinHeight="32"
-                        Padding="12,4"
-                        Visibility="Collapsed"
-                        Click="OnActionClick"/>
+                <StackPanel Grid.Column="2"
+                            Orientation="Horizontal"
+                            Spacing="8"
+                            VerticalAlignment="Center">
+                    <Button x:Name="SecondaryActionButton"
+                            MinHeight="32"
+                            Padding="12,4"
+                            Visibility="Collapsed"
+                            Style="{ThemeResource SubtleButtonStyle}"
+                            Click="OnSecondaryActionClick"/>
+                    <Button x:Name="ActionButton"
+                            MinHeight="32"
+                            Padding="12,4"
+                            Visibility="Collapsed"
+                            Click="OnActionClick"/>
+                </StackPanel>
 
                 <Button x:Uid="Controls_Notifications_NotificationToast__Auto_600" x:Name="CloseButton"
                         Grid.Column="3"

--- a/src/Wavee.UI.WinUI/Controls/Notifications/NotificationToast.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Notifications/NotificationToast.xaml.cs
@@ -61,6 +61,16 @@ public sealed partial class NotificationToast : UserControl
         set => SetValue(ActionLabelProperty, value);
     }
 
+    public static readonly DependencyProperty SecondaryActionLabelProperty =
+        DependencyProperty.Register(nameof(SecondaryActionLabel), typeof(string), typeof(NotificationToast),
+            new PropertyMetadata(null, OnSecondaryActionLabelChanged));
+
+    public string? SecondaryActionLabel
+    {
+        get => (string?)GetValue(SecondaryActionLabelProperty);
+        set => SetValue(SecondaryActionLabelProperty, value);
+    }
+
     public static readonly DependencyProperty IsActionEnabledProperty =
         DependencyProperty.Register(nameof(IsActionEnabled), typeof(bool), typeof(NotificationToast),
             new PropertyMetadata(true, OnIsActionEnabledChanged));
@@ -72,6 +82,7 @@ public sealed partial class NotificationToast : UserControl
     }
 
     public event RoutedEventHandler? ActionClick;
+    public event RoutedEventHandler? SecondaryActionClick;
     public event RoutedEventHandler? CloseRequested;
 
     private static void OnIsOpenChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -103,9 +114,22 @@ public sealed partial class NotificationToast : UserControl
             : Visibility.Visible;
     }
 
+    private static void OnSecondaryActionLabelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var toast = (NotificationToast)d;
+        var label = e.NewValue as string;
+        toast.SecondaryActionButton.Content = label;
+        toast.SecondaryActionButton.Visibility = string.IsNullOrEmpty(label)
+            ? Visibility.Collapsed
+            : Visibility.Visible;
+    }
+
     private static void OnIsActionEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        ((NotificationToast)d).ActionButton.IsEnabled = (bool)e.NewValue;
+        var toast = (NotificationToast)d;
+        var enabled = (bool)e.NewValue;
+        toast.ActionButton.IsEnabled = enabled;
+        toast.SecondaryActionButton.IsEnabled = enabled;
     }
 
     private void ApplySeverity(AppNotificationSeverity severity)
@@ -124,5 +148,6 @@ public sealed partial class NotificationToast : UserControl
     }
 
     private void OnActionClick(object sender, RoutedEventArgs e) => ActionClick?.Invoke(this, e);
+    private void OnSecondaryActionClick(object sender, RoutedEventArgs e) => SecondaryActionClick?.Invoke(this, e);
     private void OnCloseClick(object sender, RoutedEventArgs e) => CloseRequested?.Invoke(this, e);
 }

--- a/src/Wavee.UI.WinUI/Controls/Reorder/ReorderController.cs
+++ b/src/Wavee.UI.WinUI/Controls/Reorder/ReorderController.cs
@@ -92,6 +92,11 @@ public sealed class ReorderController
     private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
     {
         if (sender is not FrameworkElement row || !_host.CanReorder) return;
+        // Touch must scroll the list, never drag-reorder: a finger pan crosses the
+        // 6px threshold and would otherwise lift the row (issue #4). Reorder stays on
+        // mouse/pen (press-drag) and keyboard (Space + arrows); touch users reorder
+        // via the row context menu / cross-surface actions.
+        if (PointerInput.IsTouch(e)) return;
         var pp = e.GetCurrentPoint(row);
         if (pp.Properties.IsRightButtonPressed || pp.Properties.IsMiddleButtonPressed) return;
 

--- a/src/Wavee.UI.WinUI/Controls/Settings/AboutSettingsSection.xaml
+++ b/src/Wavee.UI.WinUI/Controls/Settings/AboutSettingsSection.xaml
@@ -101,10 +101,10 @@
                     <FontIcon Glyph="&#xE8A7;" FontSize="14"/>
                 </controls:SettingsCard>
 
-                <controls:SettingsCard x:Uid="Controls_Settings_AboutSettingsSection__SettingsCard_100" Header="Report an issue on GitHub"
-                                       Description="Packages your recent logs into a zip and opens GitHub Issues"
+                <controls:SettingsCard x:Uid="Controls_Settings_AboutSettingsSection__SettingsCard_100" Header="Report a problem / export logs"
+                                       Description="Bundles your logs (including the audio engine) into a zip you can send via GitHub or email"
                                        IsClickEnabled="True"
-                                       Click="ReportOnGitHub_Click"
+                                       Click="ReportProblem_Click"
                                        Tag="help">
                     <controls:SettingsCard.HeaderIcon>
                         <FontIcon Glyph="&#xE943;"/>

--- a/src/Wavee.UI.WinUI/Controls/Settings/AboutSettingsSection.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Settings/AboutSettingsSection.xaml.cs
@@ -288,9 +288,9 @@ public sealed partial class AboutSettingsSection : UserControl, ISettingsSearchF
         await Launcher.LaunchUriAsync(new Uri("https://github.com/christosk92/WaveeMusic/blob/master/LICENSE"));
     }
 
-    private async void ReportOnGitHub_Click(object sender, RoutedEventArgs e)
+    private async void ReportProblem_Click(object sender, RoutedEventArgs e)
     {
-        await CrashReportPackager.OpenIssueReportAsync();
+        await DiagnosticsReporter.ReportAsync(XamlRoot);
     }
 }
 

--- a/src/Wavee.UI.WinUI/Controls/Splash/BootSplash.xaml
+++ b/src/Wavee.UI.WinUI/Controls/Splash/BootSplash.xaml
@@ -4,7 +4,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:branding="using:Wavee.UI.WinUI.Controls.Branding"
-    xmlns:cards="using:Wavee.UI.WinUI.Controls.Cards"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
@@ -19,15 +18,21 @@
             <SolidColorBrush Color="#FF0F0F0F"/>
         </Grid.Background>
 
-        <!-- Animated mesh gradient: same shader stack used by the home cards.
-             PrimaryColor stays close to the base so the gradient feels like a
-             slow shimmer rather than two competing colours. -->
-        <cards:AnimatedHeroBackground
-            x:Name="PART_Background"
-            HorizontalAlignment="Stretch"
-            VerticalAlignment="Stretch"
-            PrimaryColor="#FF0E1B12"
-            AccentColor="#FF1DB954"/>
+        <!-- Static gradient backdrop. The cold-start splash must NEVER depend on a graphics
+             device: a Win2D / ComputeSharp shader here crashes unrecoverably on GPU-less
+             environments (e.g. Windows Sandbox, some VMs / RDP) before any crash handler can
+             run or log it (stowed exception in the composition layer). A static radial glow
+             reads near-identically for the ~700ms splash; the animated mesh still renders on
+             the home / playlist surfaces once the app is up. -->
+        <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+            <Rectangle.Fill>
+                <RadialGradientBrush Center="0.35,0.4" GradientOrigin="0.35,0.4" RadiusX="0.9" RadiusY="0.9">
+                    <GradientStop Color="#FF143824" Offset="0.0"/>
+                    <GradientStop Color="#FF0E1B12" Offset="0.55"/>
+                    <GradientStop Color="#FF0B0F0C" Offset="1.0"/>
+                </RadialGradientBrush>
+            </Rectangle.Fill>
+        </Rectangle>
 
         <!-- Vignette so the wordmark stays legible everywhere across the gradient.
              Centre is fully transparent; edges fade toward the base. -->

--- a/src/Wavee.UI.WinUI/Controls/Splash/BootSplash.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Splash/BootSplash.xaml.cs
@@ -18,17 +18,10 @@ public sealed partial class BootSplash : UserControl
     {
         InitializeComponent();
         Loaded += OnLoaded;
-        Unloaded += OnUnloaded;
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
         => _ = ShowRingAfterDelayAsync();
-
-    private void OnUnloaded(object sender, RoutedEventArgs e)
-    {
-        if (PART_Background is { } bg)
-            bg.IsPaused = true;
-    }
 
     private async Task ShowRingAfterDelayAsync()
     {
@@ -45,9 +38,6 @@ public sealed partial class BootSplash : UserControl
     {
         if (_faded) return Task.CompletedTask;
         _faded = true;
-
-        // Stop spending GPU on a splash that's about to disappear.
-        PART_Background.IsPaused = true;
 
         var visual = ElementCompositionPreview.GetElementVisual(this);
         var compositor = visual.Compositor;

--- a/src/Wavee.UI.WinUI/Data/Contexts/NotificationService.cs
+++ b/src/Wavee.UI.WinUI/Data/Contexts/NotificationService.cs
@@ -23,6 +23,7 @@ internal sealed partial class NotificationService : ObservableObject, INotificat
     private readonly IActivityService? _activityService;
     private DispatcherTimer? _autoDismissTimer;
     private Func<Task>? _currentAction;
+    private Func<Task>? _currentSecondaryAction;
 
     [ObservableProperty]
     public partial bool IsOpen { get; set; }
@@ -35,6 +36,9 @@ internal sealed partial class NotificationService : ObservableObject, INotificat
 
     [ObservableProperty]
     public partial string? ActionLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string? SecondaryActionLabel { get; set; }
 
     [ObservableProperty]
     public partial bool IsActionBusy { get; set; }
@@ -73,7 +77,9 @@ internal sealed partial class NotificationService : ObservableObject, INotificat
         Message = notification.Message;
         Severity = notification.Severity;
         ActionLabel = notification.ActionLabel;
+        SecondaryActionLabel = notification.SecondaryActionLabel;
         _currentAction = notification.Action;
+        _currentSecondaryAction = notification.SecondaryAction;
         IsActionBusy = false;
         IsOpen = true;
 
@@ -89,7 +95,7 @@ internal sealed partial class NotificationService : ObservableObject, INotificat
         // caller didn't pick a duration, give actionable toasts a longer window
         // so the user can read + reach the action button before it closes.
         var dismissAfter = notification.AutoDismissAfter
-            ?? (notification.ActionLabel != null
+            ?? (notification.ActionLabel != null || notification.SecondaryActionLabel != null
                 ? TimeSpan.FromSeconds(8)
                 : TimeSpan.FromSeconds(5));
 
@@ -138,7 +144,9 @@ internal sealed partial class NotificationService : ObservableObject, INotificat
         IsOpen = false;
         Message = null;
         ActionLabel = null;
+        SecondaryActionLabel = null;
         _currentAction = null;
+        _currentSecondaryAction = null;
         IsActionBusy = false;
 
         _messenger.Send(new NotificationDismissedMessage());
@@ -156,6 +164,25 @@ internal sealed partial class NotificationService : ObservableObject, INotificat
         {
             IsActionBusy = true;
             await _currentAction();
+        }
+        finally
+        {
+            IsActionBusy = false;
+        }
+    }
+
+    /// <summary>
+    /// Invokes the current notification's secondary async action callback, if any.
+    /// Disables the action buttons while the task is running.
+    /// </summary>
+    public async Task InvokeSecondaryActionAsync()
+    {
+        if (_currentSecondaryAction == null || IsActionBusy) return;
+
+        try
+        {
+            IsActionBusy = true;
+            await _currentSecondaryAction();
         }
         finally
         {

--- a/src/Wavee.UI.WinUI/Data/Contexts/PlaybackService.cs
+++ b/src/Wavee.UI.WinUI/Data/Contexts/PlaybackService.cs
@@ -76,12 +76,56 @@ internal sealed partial class PlaybackService : ObservableObject, IPlaybackServi
                 _ => NotificationSeverity.Error
             };
 
-            _notificationService.Show(new NotificationInfo
+            // This is the toast a user actually hits at play-time when the out-of-process
+            // audio engine isn't available (issue #4): "No active device and no local
+            // playback engine available." Gate on the engine not running — covers Failed,
+            // Disconnected, and a stuck restart — rather than State==Failed alone (a down
+            // engine is frequently Disconnected, which is why the button never appeared).
+            // Normal remote-control DeviceUnavailable messages ("device not found", "reorder
+            // only on local device") happen while the local engine IS running, so they stay plain.
+            var apm = Wavee.UI.WinUI.Helpers.Application.AppLifecycleHelper.AudioProcessManager;
+            var engineFailed = error.Kind == PlaybackErrorKind.DeviceUnavailable
+                && apm is not null
+                && !apm.IsRunning;
+
+            NotificationInfo info;
+            if (engineFailed)
             {
-                Message = error.Message,
-                Severity = severity,
-                AutoDismissAfter = TimeSpan.FromSeconds(5)
-            });
+                info = new NotificationInfo
+                {
+                    Message = error.Message,
+                    Severity = severity,
+                    AutoDismissAfter = TimeSpan.FromSeconds(10),
+                    ActionLabel = Wavee.UI.WinUI.Services.AppLocalization.GetString("Retry"),
+                    Action = async () =>
+                    {
+                        try
+                        {
+                            await apm!.StopAsync();
+                            await Wavee.UI.WinUI.Helpers.Application.AppLifecycleHelper
+                                .InitializeOutOfProcessAudioAsync(_session, _logger);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger?.LogWarning(ex, "Audio engine retry from playback toast failed");
+                        }
+                    },
+                    SecondaryActionLabel = Wavee.UI.WinUI.Services.AppLocalization.GetString("Diagnostics_Report"),
+                    SecondaryAction = () => Wavee.UI.WinUI.Services.DiagnosticsReporter.ReportAsync(
+                        context: $"Playback failed — audio engine not running: {error.Message}")
+                };
+            }
+            else
+            {
+                info = new NotificationInfo
+                {
+                    Message = error.Message,
+                    Severity = severity,
+                    AutoDismissAfter = TimeSpan.FromSeconds(5)
+                };
+            }
+
+            _notificationService.Show(info);
         });
     }
 

--- a/src/Wavee.UI.WinUI/Data/Contracts/INotificationService.cs
+++ b/src/Wavee.UI.WinUI/Data/Contracts/INotificationService.cs
@@ -15,6 +15,7 @@ public interface INotificationService : INotifyPropertyChanged
     string? Message { get; }
     NotificationSeverity Severity { get; }
     string? ActionLabel { get; }
+    string? SecondaryActionLabel { get; }
     bool IsActionBusy { get; }
 
     /// <summary>
@@ -37,4 +38,9 @@ public interface INotificationService : INotifyPropertyChanged
     /// Invokes the action callback asynchronously. The button is disabled while busy.
     /// </summary>
     Task InvokeActionAsync();
+
+    /// <summary>
+    /// Invokes the secondary action callback asynchronously. The buttons are disabled while busy.
+    /// </summary>
+    Task InvokeSecondaryActionAsync();
 }

--- a/src/Wavee.UI.WinUI/Data/Models/NotificationInfo.cs
+++ b/src/Wavee.UI.WinUI/Data/Models/NotificationInfo.cs
@@ -28,6 +28,15 @@ public sealed record NotificationInfo
     public Func<Task>? Action { get; init; }
 
     /// <summary>
+    /// Optional label for a SECONDARY action button, rendered next to <see cref="ActionLabel"/>
+    /// (e.g. a "Report a problem" button shown alongside a primary "Retry"). Rendered only when set.
+    /// </summary>
+    public string? SecondaryActionLabel { get; init; }
+
+    /// <summary>Optional async callback invoked when the secondary action button is clicked.</summary>
+    public Func<Task>? SecondaryAction { get; init; }
+
+    /// <summary>
     /// When <c>true</c> (default), the notification is also recorded in the
     /// activity-bell history. Set <c>false</c> for high-frequency transient
     /// confirmations (e.g. "Added to queue") that would otherwise flood the bell.

--- a/src/Wavee.UI.WinUI/DragDrop/ManualDragAttachment.cs
+++ b/src/Wavee.UI.WinUI/DragDrop/ManualDragAttachment.cs
@@ -57,9 +57,12 @@ public static class ManualDragAttachment
 
     private static void OnPointerPressed(UIElement element, DragState state, PointerRoutedEventArgs e)
     {
-        // Only mouse-left / pen / touch initiate a drag. Right-click, middle-click
-        // and the keyboard "context menu" key should still bubble through to the
-        // owning control's existing handlers (right-click context menus etc.).
+        // Only mouse-left / pen initiate a drag. Touch must scroll the list — a finger
+        // pan would otherwise cross the threshold and start a drag (issue #4) — so it
+        // is excluded here; touch users use the long-press context menu instead.
+        // Right-click and middle-click still bubble through to the owning control's
+        // existing handlers (right-click context menus etc.).
+        if (PointerInput.IsTouch(e)) return;
         var pp = e.GetCurrentPoint(element);
         if (pp.Properties.IsRightButtonPressed || pp.Properties.IsMiddleButtonPressed) return;
 

--- a/src/Wavee.UI.WinUI/DragDrop/PointerInput.cs
+++ b/src/Wavee.UI.WinUI/DragDrop/PointerInput.cs
@@ -1,0 +1,20 @@
+using Microsoft.UI.Input;
+using Microsoft.UI.Xaml.Input;
+
+namespace Wavee.UI.WinUI.DragDrop;
+
+/// <summary>
+/// Helpers for distinguishing pointer input kinds inside custom gesture controllers.
+/// </summary>
+internal static class PointerInput
+{
+    /// <summary>
+    /// True when the gesture originates from touch. The custom press-drag controllers
+    /// (<see cref="Wavee.UI.WinUI.Controls.Reorder.ReorderController"/> and
+    /// <see cref="ManualDragAttachment"/>) exclude touch so a finger pan scrolls the
+    /// list instead of lifting a row (issue #4). Mouse and pen still drag-reorder;
+    /// keyboard reorder is unaffected.
+    /// </summary>
+    public static bool IsTouch(PointerRoutedEventArgs e)
+        => e.Pointer.PointerDeviceType == PointerDeviceType.Touch;
+}

--- a/src/Wavee.UI.WinUI/Helpers/Application/AppLifecycleHelper.cs
+++ b/src/Wavee.UI.WinUI/Helpers/Application/AppLifecycleHelper.cs
@@ -1091,6 +1091,12 @@ public static class AppLifecycleHelper
     {
         try
         {
+            // TEST: uncomment to simulate the issue #4 audio-engine failure so the
+            // failure toast (Retry + Report a problem) and the diagnostics bundle can be
+            // exercised. Re-comment (or clear) to restore real audio. Also settable via the
+            // WAVEE_SIMULATE_AUDIO_FAILURE env var ("provisioning" | "timeout" | "missing-exe").
+            //Wavee.AudioIpc.AudioProcessManager.SimulateStartupFailure = "provisioning";
+
             InitializeTrackMetadataEnricher(session, logger);
 
             _audioProcessManager = new Wavee.AudioIpc.AudioProcessManager(logger);
@@ -1156,6 +1162,7 @@ public static class AppLifecycleHelper
                             break;
 
                         case Wavee.AudioIpc.AudioProcessState.Failed:
+                            var audioFailureMessage = message;
                             notifService?.Show(new Data.Models.NotificationInfo
                             {
                                 Message = message,
@@ -1168,7 +1175,13 @@ public static class AppLifecycleHelper
                                         await _audioProcessManager.StopAsync();
                                         await InitializeOutOfProcessAudioAsync(session, logger);
                                     }
-                                }
+                                },
+                                // One-click path to a complete diagnostics bundle (incl. the
+                                // AudioHost log) so this exact failure can be reported. The
+                                // failure text seeds the issue/email description.
+                                SecondaryActionLabel = AppLocalization.GetString("Diagnostics_Report"),
+                                SecondaryAction = () => Wavee.UI.WinUI.Services.DiagnosticsReporter.ReportAsync(
+                                    context: $"Audio engine failure: {audioFailureMessage}")
                             });
                             if (audioActivityId != null)
                                 actSvc?.Fail(audioActivityId.Value, message);

--- a/src/Wavee.UI.WinUI/Helpers/Application/AppPaths.cs
+++ b/src/Wavee.UI.WinUI/Helpers/Application/AppPaths.cs
@@ -9,6 +9,22 @@ public static class AppPaths
         Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
         "Wavee");
 
+    /// <summary>
+    /// Local (non-roaming) data root: <c>%LOCALAPPDATA%\Wavee</c>. The out-of-process
+    /// AudioHost and the native-dependency provisioner write here. Under MSIX this and
+    /// <see cref="AppDataDirectory"/> redirect to different package-container subfolders,
+    /// so a diagnostics bundle must gather from both.
+    /// </summary>
+    public static string LocalAppDataDirectory { get; } = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Wavee");
+
+    /// <summary><c>%LOCALAPPDATA%\Wavee\Logs</c> — the AudioHost's Serilog output (audiohost-*.log).</summary>
+    public static string AudioHostLogsDirectory { get; } = Path.Combine(LocalAppDataDirectory, "Logs");
+
+    /// <summary><c>%LOCALAPPDATA%\Wavee\NativeDeps</c> — native-dep cache + *.failure.json markers.</summary>
+    public static string NativeDepsDirectory { get; } = Path.Combine(LocalAppDataDirectory, "NativeDeps");
+
     public static string LogsDirectory { get; } = Path.Combine(AppDataDirectory, "logs");
 
     public static string RollingLogFilePath { get; } = Path.Combine(LogsDirectory, "wavee-.log");

--- a/src/Wavee.UI.WinUI/Services/CrashReportPackager.cs
+++ b/src/Wavee.UI.WinUI/Services/CrashReportPackager.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Wavee.UI.WinUI.Helpers.Application;
 using Windows.System;
@@ -13,20 +15,28 @@ using Windows.System;
 namespace Wavee.UI.WinUI.Services;
 
 /// <summary>
-/// Packages local diagnostic artifacts (crash logs, rolling Serilog logs,
-/// DRM logs) into a single zip the user can drag onto a GitHub issue. No
-/// remote upload — the user explicitly attaches the file themselves.
+/// Packages local diagnostic artifacts into a single zip the user can drag onto a
+/// GitHub issue or attach to an email. No remote upload — the user explicitly attaches
+/// the file themselves.
+///
+/// <para>The bundle deliberately spans <b>both</b> data roots: the roaming app logs
+/// (<see cref="AppPaths.LogsDirectory"/>) <i>and</i> the local-only AudioHost logs +
+/// native-dependency failure markers (<see cref="AppPaths.AudioHostLogsDirectory"/>,
+/// <see cref="AppPaths.NativeDepsDirectory"/>). The AudioHost log is the single most
+/// useful artifact for "cannot connect to the audio engine" reports, and it lives in a
+/// different folder (redirected differently under MSIX) than the rest.</para>
 /// </summary>
 public static class CrashReportPackager
 {
     private const string GitHubIssuesNewUrl = "https://github.com/christosk92/WaveeMusic/issues/new";
+    private const string MaintainerEmail = "christos@isoplanner.app";
     private const int MaxLogFiles = 5;
     private const long MaxIndividualFileBytes = 5 * 1024 * 1024;
 
     /// <summary>
     /// Writes a zip containing recent diagnostic files to the user's temp folder
     /// and returns its path. Returns <c>null</c> if nothing diagnostic exists
-    /// (a fresh install with no crashes).
+    /// (a fresh install with no logs at all).
     /// </summary>
     public static async Task<string?> CreateZipAsync()
     {
@@ -35,6 +45,9 @@ public static class CrashReportPackager
 
         var zipName = $"wavee-logs-{DateTime.Now:yyyyMMdd-HHmmss}.zip";
         var zipPath = Path.Combine(Path.GetTempPath(), zipName);
+
+        // Snapshot AudioHost diagnostics on the UI thread before the Task.Run hop.
+        var audio = AudioHostSnapshot.Capture();
 
         await Task.Run(() =>
         {
@@ -74,16 +87,7 @@ public static class CrashReportPackager
                 var manifestEntry = archive.CreateEntry("manifest.txt", CompressionLevel.Optimal);
                 using var entryStream = manifestEntry.Open();
                 using var writer = new StreamWriter(entryStream);
-                writer.WriteLine($"Wavee diagnostic bundle generated {DateTime.Now:O}");
-                writer.WriteLine($"App version: {GetAppVersion()}");
-                writer.WriteLine($"OS: {Environment.OSVersion} ({(Environment.Is64BitOperatingSystem ? "x64" : "x86")})");
-                writer.WriteLine($"Process arch: {(Environment.Is64BitProcess ? "x64" : "x86")}");
-                writer.WriteLine($"CLR: {Environment.Version}");
-                writer.WriteLine($"Culture: {System.Globalization.CultureInfo.CurrentUICulture.Name}");
-                writer.WriteLine();
-                writer.WriteLine("Files included:");
-                foreach (var (_, entryName) in sources)
-                    writer.WriteLine($"  - {entryName}");
+                WriteManifest(writer, sources, audio);
             }
             catch
             {
@@ -94,15 +98,44 @@ public static class CrashReportPackager
         return zipPath;
     }
 
+    private static void WriteManifest(
+        TextWriter writer,
+        List<(string SourcePath, string EntryName)> sources,
+        AudioHostSnapshot audio)
+    {
+        writer.WriteLine($"Wavee diagnostic bundle generated {DateTime.Now:O}");
+        writer.WriteLine($"App version: {GetAppVersion()}");
+        // Report real architectures: Is64Bit* mislabels an ARM64 machine (and the
+        // x64-emulated AudioHost) as "x64", which hides the actual platform on reports
+        // like issue #4 (Surface Pro 11 / Snapdragon).
+        writer.WriteLine($"OS: {Environment.OSVersion} ({RuntimeInformation.OSArchitecture})");
+        writer.WriteLine($"Process arch: {RuntimeInformation.ProcessArchitecture}");
+        writer.WriteLine($"CLR: {Environment.Version}");
+        writer.WriteLine($"Culture: {CultureInfo.CurrentUICulture.Name}");
+
+        writer.WriteLine();
+        writer.WriteLine("AudioHost:");
+        writer.WriteLine($"  exe: {audio.Path}");
+        writer.WriteLine($"  exists: {audio.Exists}");
+        writer.WriteLine($"  last exit code: {audio.LastExitCode?.ToString(CultureInfo.InvariantCulture) ?? "n/a (running or never started)"}");
+        writer.WriteLine($"  state: {audio.State}");
+        writer.WriteLine($"  bass.dll cached: {File.Exists(Path.Combine(AppPaths.NativeDepsDirectory, "win-x64", "bass.dll"))}");
+        writer.WriteLine($"  portaudio.dll (arm64) cached: {File.Exists(Path.Combine(AppPaths.NativeDepsDirectory, "win-arm64", "portaudio.dll"))}");
+
+        writer.WriteLine();
+        writer.WriteLine("Files included:");
+        foreach (var (_, entryName) in sources)
+            writer.WriteLine($"  - {entryName}");
+    }
+
     /// <summary>
-    /// Builds the suggested issue body — version + OS info — for the GitHub
-    /// new-issue URL. Don't include the zip path: the user attaches the file
-    /// manually in the browser.
+    /// Builds the suggested GitHub issue body — version + OS info. Don't include the zip
+    /// path: the user attaches the file manually in the browser.
     /// </summary>
-    public static string BuildIssueBodyTemplate()
+    public static string BuildIssueBodyTemplate(string? context = null)
         => $"""
             ## Describe the bug
-            <!-- A clear and concise description of what the bug is. -->
+            {context ?? "<!-- A clear and concise description of what the bug is. -->"}
 
             ## Steps to reproduce
             1.
@@ -120,12 +153,83 @@ public static class CrashReportPackager
 
             ## Environment
             - **Wavee:** {GetAppVersion()}
-            - **OS:** {Environment.OSVersion}
-            - **Arch:** {(Environment.Is64BitProcess ? "x64" : "x86")}
-            - **Culture:** {System.Globalization.CultureInfo.CurrentUICulture.Name}
+            - **OS:** {Environment.OSVersion} ({RuntimeInformation.OSArchitecture})
+            - **Arch:** {RuntimeInformation.ProcessArchitecture}
+            - **Culture:** {CultureInfo.CurrentUICulture.Name}
             """;
 
-    public static async Task OpenIssueReportAsync()
+    /// <summary>Plain-text body for a mailto: draft. The user attaches the revealed zip.</summary>
+    public static string BuildEmailBody(string? context = null)
+        => $"""
+            Describe the problem:
+            {(context is null ? "" : context + "\n")}
+
+            Please attach the wavee-logs zip that File Explorer just opened.
+
+            Environment
+            - Wavee: {GetAppVersion()}
+            - OS: {Environment.OSVersion} ({RuntimeInformation.OSArchitecture})
+            - Process arch: {RuntimeInformation.ProcessArchitecture}
+            - Culture: {CultureInfo.CurrentUICulture.Name}
+            """;
+
+    /// <summary>Reveal the bundle in File Explorer (selected) so the user can drag/attach it.</summary>
+    public static void RevealInExplorer(string? zipPath)
+    {
+        if (string.IsNullOrEmpty(zipPath) || !File.Exists(zipPath)) return;
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "explorer.exe",
+                Arguments = $"/select,\"{zipPath}\"",
+                UseShellExecute = true,
+            });
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Explorer /select for {zipPath} failed: {ex}");
+        }
+    }
+
+    /// <summary>Open a pre-filled new GitHub issue in the browser.</summary>
+    public static async Task OpenGitHubIssueAsync(string? body = null)
+    {
+        body ??= BuildIssueBodyTemplate();
+        var url = $"{GitHubIssuesNewUrl}?body={WebUtility.UrlEncode(body)}";
+        await Launcher.LaunchUriAsync(new Uri(url));
+    }
+
+    /// <summary>Open a pre-filled email draft to the maintainer (mailto can't auto-attach).</summary>
+    public static async Task OpenEmailDraftAsync(string? body = null)
+    {
+        body ??= BuildEmailBody();
+        var subject = $"WaveeMusic diagnostics ({GetAppVersion()})";
+        var uri = $"mailto:{MaintainerEmail}?subject={Uri.EscapeDataString(subject)}&body={Uri.EscapeDataString(body)}";
+        await Launcher.LaunchUriAsync(new Uri(uri));
+    }
+
+    /// <summary>Copy the bundle's file path to the clipboard.</summary>
+    public static void CopyZipPath(string zipPath)
+    {
+        try
+        {
+            var package = new Windows.ApplicationModel.DataTransfer.DataPackage();
+            package.SetText(zipPath);
+            Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(package);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Copy zip path failed: {ex}");
+        }
+    }
+
+    /// <summary>
+    /// Quick "build → reveal → open GitHub issue" path. Used by the crash-recovery page,
+    /// where a chooser dialog would be awkward. The Settings entry uses
+    /// <see cref="DiagnosticsReporter.ReportAsync"/> (GitHub / Email / Open folder chooser).
+    /// </summary>
+    public static async Task OpenIssueReportAsync(string? context = null)
     {
         string? zipPath = null;
         try
@@ -137,45 +241,36 @@ public static class CrashReportPackager
             Debug.WriteLine($"CrashReportPackager.CreateZipAsync failed: {ex}");
         }
 
-        // Reveal the zip in File Explorer so the user can drag it onto the
-        // GitHub issue form. A missing zip (fresh install, no logs) just skips
-        // this step and still opens the issue form.
-        if (!string.IsNullOrEmpty(zipPath) && File.Exists(zipPath))
-        {
-            try
-            {
-                Process.Start(new ProcessStartInfo
-                {
-                    FileName = "explorer.exe",
-                    Arguments = $"/select,\"{zipPath}\"",
-                    UseShellExecute = true,
-                });
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"Explorer /select for {zipPath} failed: {ex}");
-            }
-        }
-
-        var body = BuildIssueBodyTemplate();
-        var url = $"{GitHubIssuesNewUrl}?body={WebUtility.UrlEncode(body)}";
-        await Launcher.LaunchUriAsync(new Uri(url));
+        if (zipPath is not null) RevealInExplorer(zipPath);
+        await OpenGitHubIssueAsync(BuildIssueBodyTemplate(context));
     }
 
     private static List<(string SourcePath, string EntryName)> CollectSourceFiles()
     {
         var result = new List<(string, string)>();
 
+        // Roaming: crash log + app/DRM rolling logs.
         if (File.Exists(AppPaths.CrashLogPath))
             result.Add((AppPaths.CrashLogPath, Path.GetFileName(AppPaths.CrashLogPath)));
+        if (File.Exists(AppPaths.PendingCrashReportPath))
+            result.Add((AppPaths.PendingCrashReportPath, Path.GetFileName(AppPaths.PendingCrashReportPath)));
 
         TryAddRecent(result, AppPaths.LogsDirectory, "wavee-*.log", "logs");
         TryAddRecent(result, AppPaths.LogsDirectory, "drm-*.log", "logs");
 
+        // Local-only: the out-of-process AudioHost log — the key artifact for
+        // "cannot connect to the audio engine" — plus native-dep failure markers.
+        TryAddRecent(result, AppPaths.AudioHostLogsDirectory, "audiohost-*.log", "audiohost");
+        TryAddRecent(result, AppPaths.NativeDepsDirectory, "*.failure.json", "nativedeps");
+
+        // Latest memory-diagnostics sample (one file).
+        TryAddRecent(result, AppPaths.DiagnosticsDirectory, "memory-*.csv", "diag", max: 1);
+
         return result;
     }
 
-    private static void TryAddRecent(List<(string, string)> sink, string directory, string searchPattern, string entryPrefix)
+    private static void TryAddRecent(
+        List<(string, string)> sink, string directory, string searchPattern, string entryPrefix, int max = MaxLogFiles)
     {
         try
         {
@@ -183,7 +278,7 @@ public static class CrashReportPackager
             var files = Directory.EnumerateFiles(directory, searchPattern)
                 .Select(p => new FileInfo(p))
                 .OrderByDescending(fi => fi.LastWriteTimeUtc)
-                .Take(MaxLogFiles);
+                .Take(max);
             foreach (var fi in files)
                 sink.Add((fi.FullName, Path.Combine(entryPrefix, fi.Name).Replace('\\', '/')));
         }
@@ -206,6 +301,18 @@ public static class CrashReportPackager
             // Unpackaged fallback.
             var asm = Assembly.GetExecutingAssembly().GetName().Version;
             return asm?.ToString() ?? "unknown";
+        }
+    }
+
+    /// <summary>UI-thread snapshot of AudioHost diagnostics for the (background) manifest writer.</summary>
+    private readonly record struct AudioHostSnapshot(string Path, bool Exists, int? LastExitCode, string State)
+    {
+        public static AudioHostSnapshot Capture()
+        {
+            var apm = AppLifecycleHelper.AudioProcessManager;
+            if (apm is null)
+                return new AudioHostSnapshot("<audio process manager not initialized>", false, null, "n/a");
+            return new AudioHostSnapshot(apm.AudioHostPath, apm.AudioHostExists, apm.LastExitCode, apm.State.ToString());
         }
     }
 }

--- a/src/Wavee.UI.WinUI/Services/DiagnosticsReporter.cs
+++ b/src/Wavee.UI.WinUI/Services/DiagnosticsReporter.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Wavee.UI.WinUI.Services;
+
+/// <summary>
+/// User-facing "Report a problem" flow: builds a complete diagnostics bundle (including
+/// the AudioHost log), reveals it in File Explorer, then lets the user pick how to send
+/// it — GitHub issue or email. Shared by the Settings → About card and the audio-engine
+/// failure notification so both produce the same, complete bundle.
+/// </summary>
+public static class DiagnosticsReporter
+{
+    /// <param name="xamlRoot">
+    /// XamlRoot for the chooser dialog. Falls back to the main window's content root.
+    /// </param>
+    /// <param name="context">
+    /// Optional pre-filled problem description (e.g. the audio-engine failure message).
+    /// </param>
+    public static async Task ReportAsync(XamlRoot? xamlRoot = null, string? context = null)
+    {
+        string? zipPath = null;
+        try
+        {
+            zipPath = await CrashReportPackager.CreateZipAsync();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"DiagnosticsReporter: bundle creation failed: {ex}");
+        }
+
+        // Reveal first so File Explorer is already showing the zip behind the chooser —
+        // this also satisfies the "open folder" affordance the user asked for.
+        if (zipPath is not null) CrashReportPackager.RevealInExplorer(zipPath);
+
+        xamlRoot ??= MainWindow.Instance?.Content?.XamlRoot;
+        if (xamlRoot is null)
+        {
+            // No UI surface for a dialog — fall back to the direct GitHub path.
+            await CrashReportPackager.OpenGitHubIssueAsync(CrashReportPackager.BuildIssueBodyTemplate(context));
+            return;
+        }
+
+        var hasLogs = zipPath is not null;
+        var dialog = new ContentDialog
+        {
+            XamlRoot = xamlRoot,
+            Title = AppLocalization.GetString("Diagnostics_ReportTitle"),
+            Content = AppLocalization.GetString(hasLogs ? "Diagnostics_ReportBody" : "Diagnostics_ReportBody_NoLogs"),
+            PrimaryButtonText = AppLocalization.GetString("Diagnostics_ReportGitHub"),
+            SecondaryButtonText = AppLocalization.GetString("Diagnostics_ReportEmail"),
+            CloseButtonText = AppLocalization.GetString("Diagnostics_ReportDone"),
+            DefaultButton = ContentDialogButton.Primary,
+        };
+
+        ContentDialogResult result;
+        try
+        {
+            result = await dialog.ShowAsync();
+        }
+        catch (Exception ex)
+        {
+            // Another ContentDialog is already open, or no UI thread — fall back.
+            Debug.WriteLine($"DiagnosticsReporter: dialog failed: {ex}");
+            await CrashReportPackager.OpenGitHubIssueAsync(CrashReportPackager.BuildIssueBodyTemplate(context));
+            return;
+        }
+
+        switch (result)
+        {
+            case ContentDialogResult.Primary:
+                await CrashReportPackager.OpenGitHubIssueAsync(CrashReportPackager.BuildIssueBodyTemplate(context));
+                break;
+            case ContentDialogResult.Secondary:
+                await CrashReportPackager.OpenEmailDraftAsync(CrashReportPackager.BuildEmailBody(context));
+                break;
+            // Close ("Done") — the zip is already revealed in Explorer; nothing more to do.
+        }
+    }
+}

--- a/src/Wavee.UI.WinUI/Services/UpdateService.cs
+++ b/src/Wavee.UI.WinUI/Services/UpdateService.cs
@@ -17,7 +17,11 @@ namespace Wavee.UI.WinUI.Services;
 
 public sealed partial class UpdateService : IUpdateService
 {
-    private const string GitHubReleasesUrl = "https://api.github.com/repos/christosk92/WaveeMusic/releases/latest";
+    // /releases (list) NOT /releases/latest: the "latest" endpoint silently
+    // excludes pre-releases, and every Wavee build is a pre-release (alpha/beta/rc),
+    // so it always 404'd and the in-app updater never saw a new build. The list
+    // endpoint returns all releases (newest first) including pre-releases.
+    private const string GitHubReleasesUrl = "https://api.github.com/repos/christosk92/WaveeMusic/releases?per_page=30";
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ISettingsService _settingsService;
@@ -143,15 +147,8 @@ public sealed partial class UpdateService : IUpdateService
 
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
-                // GitHub returns 404 here when the repo has no published releases yet.
-                // Treat that as "no update available" instead of surfacing a startup error.
-                IsUpdateAvailable = false;
-                LatestVersion = null;
-                Changelog = null;
-                ReleaseUrl = null;
-                Status = UpdateStatus.UpToDate;
-                LastChecked = DateTimeOffset.UtcNow;
-                _logger?.LogDebug("Update check skipped because no GitHub releases are published yet");
+                // Repo/endpoint not found — treat as "no update" rather than a startup error.
+                ReportNoUpdate("releases endpoint returned 404");
                 return;
             }
 
@@ -161,30 +158,61 @@ public sealed partial class UpdateService : IUpdateService
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
 
-            var tagName = root.GetProperty("tag_name").GetString() ?? "";
-            var rawVersion = tagName.TrimStart('v', 'V');
+            // Channel-aware selection over the full release list. A pre-release
+            // build (current version carries a -alpha/-beta/-rc tag) accepts ANY
+            // non-draft release — a stable release ranks above a pre-release of the
+            // same core version, so it's still a valid "newer". A stable build only
+            // accepts stable releases (never offers a pre-release as an update).
+            var currentParsed = TryParseReleaseVersion(CurrentVersion, out var current);
+            var includePrereleases = !currentParsed || current.Prerelease is not null;
+
+            JsonElement best = default;
+            ReleaseVersion bestVersion = default;
+            var haveBest = false;
+            var considered = 0;
+
+            if (root.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var rel in root.EnumerateArray())
+                {
+                    if (rel.TryGetProperty("draft", out var draft) && draft.GetBoolean())
+                        continue;
+
+                    var tag = rel.TryGetProperty("tag_name", out var t) ? t.GetString() ?? "" : "";
+                    if (!TryParseReleaseVersion(tag, out var ver))
+                        continue;
+
+                    if (!includePrereleases && ver.Prerelease is not null)
+                        continue;
+
+                    considered++;
+                    if (!haveBest || CompareReleaseVersions(ver, bestVersion) > 0)
+                    {
+                        best = rel;
+                        bestVersion = ver;
+                        haveBest = true;
+                    }
+                }
+            }
+
+            if (!haveBest)
+            {
+                ReportNoUpdate($"no applicable releases (includePrereleases={includePrereleases})");
+                return;
+            }
+
+            var rawVersion = (best.TryGetProperty("tag_name", out var tn) ? tn.GetString() ?? "" : "").TrimStart('v', 'V');
             LatestVersion = rawVersion;
-            Changelog = root.TryGetProperty("body", out var body) ? body.GetString() : null;
-            ReleaseUrl = root.TryGetProperty("html_url", out var url) ? url.GetString() : null;
+            Changelog = best.TryGetProperty("body", out var body) ? body.GetString() : null;
+            ReleaseUrl = best.TryGetProperty("html_url", out var url) ? url.GetString() : null;
 
-            if (TryParseReleaseVersion(rawVersion, out var latest) &&
-                TryParseReleaseVersion(CurrentVersion, out var current))
-            {
-                IsUpdateAvailable = CompareReleaseVersions(latest, current) > 0;
-                Status = IsUpdateAvailable ? UpdateStatus.UpdateAvailable : UpdateStatus.UpToDate;
-            }
-            else
-            {
-                // Can't parse — treat as up to date
-                IsUpdateAvailable = false;
-                Status = UpdateStatus.UpToDate;
-            }
-
+            IsUpdateAvailable = currentParsed && CompareReleaseVersions(bestVersion, current) > 0;
+            Status = IsUpdateAvailable ? UpdateStatus.UpdateAvailable : UpdateStatus.UpToDate;
             LastChecked = DateTimeOffset.UtcNow;
 
             _logger?.LogInformation(
-                "Update check: current={Current}, latest={Latest}, available={Available}",
-                CurrentVersion, LatestVersion, IsUpdateAvailable);
+                "Update check: current={Current}, latest={Latest}, considered={Considered}, available={Available}",
+                CurrentVersion, LatestVersion, considered, IsUpdateAvailable);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -205,6 +233,17 @@ public sealed partial class UpdateService : IUpdateService
         {
             _checkLock.Release();
         }
+    }
+
+    private void ReportNoUpdate(string reason)
+    {
+        IsUpdateAvailable = false;
+        LatestVersion = null;
+        Changelog = null;
+        ReleaseUrl = null;
+        Status = UpdateStatus.UpToDate;
+        LastChecked = DateTimeOffset.UtcNow;
+        _logger?.LogDebug("Update check: up to date ({Reason})", reason);
     }
 
     private void DetectDistribution()

--- a/src/Wavee.UI.WinUI/Strings/en-US/Resources.resw
+++ b/src/Wavee.UI.WinUI/Strings/en-US/Resources.resw
@@ -2878,10 +2878,31 @@ Supports Markdown: **bold**, _italic_, `code`, - lists</value>
     <value>Wavee recorded a crash marker, but no stacktrace could be loaded.</value>
   </data>
   <data name="Controls_Settings_AboutSettingsSection__SettingsCard_100.Header" xml:space="preserve">
-    <value>Report an issue on GitHub</value>
+    <value>Report a problem / export logs</value>
   </data>
   <data name="Controls_Settings_AboutSettingsSection__SettingsCard_100.Description" xml:space="preserve">
-    <value>Packages your recent logs into a zip and opens GitHub Issues</value>
+    <value>Bundles your logs (including the audio engine) into a zip you can send via GitHub or email</value>
+  </data>
+  <data name="Diagnostics_Report" xml:space="preserve">
+    <value>Report a problem</value>
+  </data>
+  <data name="Diagnostics_ReportTitle" xml:space="preserve">
+    <value>Report a problem</value>
+  </data>
+  <data name="Diagnostics_ReportBody" xml:space="preserve">
+    <value>Your logs (including the audio engine) are bundled and File Explorer has opened with the zip selected. Choose how to send it — then attach the zip.</value>
+  </data>
+  <data name="Diagnostics_ReportBody_NoLogs" xml:space="preserve">
+    <value>No logs were found to bundle yet. You can still open a GitHub issue or email.</value>
+  </data>
+  <data name="Diagnostics_ReportGitHub" xml:space="preserve">
+    <value>Report on GitHub</value>
+  </data>
+  <data name="Diagnostics_ReportEmail" xml:space="preserve">
+    <value>Email logs</value>
+  </data>
+  <data name="Diagnostics_ReportDone" xml:space="preserve">
+    <value>Done</value>
   </data>
   <data name="Controls_Settings_AboutSettingsSection__SettingsExpander_102.Header" xml:space="preserve">
     <value>Privacy</value>

--- a/src/Wavee.UI.WinUI/Strings/ko-KR/Resources.resw
+++ b/src/Wavee.UI.WinUI/Strings/ko-KR/Resources.resw
@@ -2876,10 +2876,31 @@
     <value>새 폴더 만들기...</value>
   </data>
   <data name="Controls_Settings_AboutSettingsSection__SettingsCard_100.Header" xml:space="preserve">
-    <value>GitHub에서 문제 신고</value>
+    <value>문제 신고 / 로그 내보내기</value>
   </data>
   <data name="Controls_Settings_AboutSettingsSection__SettingsCard_100.Description" xml:space="preserve">
-    <value>최근 로그를 zip으로 패키지하고 GitHub Issues를 엽니다</value>
+    <value>로그(오디오 엔진 포함)를 zip으로 묶어 GitHub 또는 이메일로 보낼 수 있습니다</value>
+  </data>
+  <data name="Diagnostics_Report" xml:space="preserve">
+    <value>문제 신고</value>
+  </data>
+  <data name="Diagnostics_ReportTitle" xml:space="preserve">
+    <value>문제 신고</value>
+  </data>
+  <data name="Diagnostics_ReportBody" xml:space="preserve">
+    <value>로그(오디오 엔진 포함)가 zip으로 묶였고, 파일 탐색기에 해당 zip이 선택된 상태로 열렸습니다. 보낼 방법을 선택한 뒤 zip 파일을 첨부해 주세요.</value>
+  </data>
+  <data name="Diagnostics_ReportBody_NoLogs" xml:space="preserve">
+    <value>아직 묶을 로그가 없습니다. 그래도 GitHub 이슈를 열거나 이메일을 보낼 수 있습니다.</value>
+  </data>
+  <data name="Diagnostics_ReportGitHub" xml:space="preserve">
+    <value>GitHub에 신고</value>
+  </data>
+  <data name="Diagnostics_ReportEmail" xml:space="preserve">
+    <value>이메일로 보내기</value>
+  </data>
+  <data name="Diagnostics_ReportDone" xml:space="preserve">
+    <value>완료</value>
   </data>
   <data name="Controls_Settings_AboutSettingsSection__SettingsExpander_102.Header" xml:space="preserve">
     <value>개인정보</value>

--- a/src/Wavee.UI.WinUI/ViewModels/ShellViewModel.cs
+++ b/src/Wavee.UI.WinUI/ViewModels/ShellViewModel.cs
@@ -368,6 +368,7 @@ public sealed partial class ShellViewModel : ObservableObject, IDisposable
     }
     public string? NotificationMessage => _notificationService.Message;
     public string? NotificationActionLabel => _notificationService.ActionLabel;
+    public string? NotificationSecondaryActionLabel => _notificationService.SecondaryActionLabel;
     public bool HasNotificationAction => _notificationService.ActionLabel != null;
     public bool IsNotificationActionEnabled => !_notificationService.IsActionBusy;
 
@@ -557,6 +558,9 @@ public sealed partial class ShellViewModel : ObservableObject, IDisposable
             case nameof(INotificationService.ActionLabel):
                 OnPropertyChanged(nameof(NotificationActionLabel));
                 OnPropertyChanged(nameof(HasNotificationAction));
+                break;
+            case nameof(INotificationService.SecondaryActionLabel):
+                OnPropertyChanged(nameof(NotificationSecondaryActionLabel));
                 break;
             case nameof(INotificationService.IsActionBusy):
                 OnPropertyChanged(nameof(IsNotificationActionEnabled));

--- a/src/Wavee.UI.WinUI/Views/ShellPage.xaml
+++ b/src/Wavee.UI.WinUI/Views/ShellPage.xaml
@@ -140,8 +140,10 @@
             Message="{x:Bind ViewModel.NotificationMessage, Mode=OneWay}"
             Severity="{x:Bind ViewModel.NotificationSeverity, Mode=OneWay}"
             ActionLabel="{x:Bind ViewModel.NotificationActionLabel, Mode=OneWay}"
+            SecondaryActionLabel="{x:Bind ViewModel.NotificationSecondaryActionLabel, Mode=OneWay}"
             IsActionEnabled="{x:Bind ViewModel.IsNotificationActionEnabled, Mode=OneWay}"
             ActionClick="NotificationAction_Click"
+            SecondaryActionClick="NotificationSecondaryAction_Click"
             CloseRequested="Notification_CloseRequested"/>
 
         <!-- Browser-style zoom HUD. Pops in top-center on Ctrl+/-/0 (or when

--- a/src/Wavee.UI.WinUI/Views/ShellPage.xaml.cs
+++ b/src/Wavee.UI.WinUI/Views/ShellPage.xaml.cs
@@ -558,6 +558,21 @@ public sealed partial class ShellPage : UserControl
         }
     }
 
+    private async void NotificationSecondaryAction_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var notificationService = CommunityToolkit.Mvvm.DependencyInjection.Ioc.Default
+                .GetService<INotificationService>();
+            if (notificationService != null)
+                await notificationService.InvokeSecondaryActionAsync();
+        }
+        catch (System.Exception ex)
+        {
+            _logger?.LogWarning(ex, "NotificationSecondaryAction_Click failed");
+        }
+    }
+
     private void Notification_CloseRequested(object sender, RoutedEventArgs e)
     {
         CommunityToolkit.Mvvm.DependencyInjection.Ioc.Default

--- a/src/Wavee/AudioIpc/AudioProcessManager.cs
+++ b/src/Wavee/AudioIpc/AudioProcessManager.cs
@@ -35,6 +35,18 @@ public sealed class AudioProcessManager : IAsyncDisposable
     /// </summary>
     public static bool UseVerboseLogging { get; set; }
 
+    /// <summary>
+    /// TEST HOOK — when non-empty, the next AudioHost launch is short-circuited into a
+    /// simulated startup failure so the failure UX (Retry + Report a problem) and the
+    /// diagnostics bundle can be exercised without a real audio fault. Defaults from the
+    /// <c>WAVEE_SIMULATE_AUDIO_FAILURE</c> environment variable. Recognized values:
+    /// <c>"provisioning"</c> (default — mimics the issue #4 native-dependency failure:
+    /// exit code 3 + a bass-win-x64.failure.json marker), <c>"timeout"</c>, <c>"missing-exe"</c>.
+    /// Leave null/empty in production. Remove before shipping.
+    /// </summary>
+    public static string? SimulateStartupFailure { get; set; } =
+        Environment.GetEnvironmentVariable("WAVEE_SIMULATE_AUDIO_FAILURE");
+
     private readonly ILogger? _logger;
     private readonly string _audioHostPath;
     private readonly CancellationTokenSource _cts = new();
@@ -53,6 +65,7 @@ public sealed class AudioProcessManager : IAsyncDisposable
     private int _restartInProgress; // 0 = idle, 1 = restarting (guards against double-trigger)
     private int _handoffInProgress; // 1 while this UI is handing AudioHost to a replacement UI process
     private Timer? _heartbeatTimer;
+    private int? _lastExitCode; // exit code of the most recent AudioHost exit (diagnostics)
 
     // Demand-driven readiness gate. EnsureConnectedAsync awaits this TCS so callers
     // (e.g. ConnectCommandExecutor at play-time) can join an in-flight restart and
@@ -93,6 +106,16 @@ public sealed class AudioProcessManager : IAsyncDisposable
     private const int HeartbeatTimeoutMs = 10000;
     private long _lastPongTimestamp;
 
+    /// <summary>
+    /// How long the UI waits for a freshly-launched AudioHost to open its pipe. Generous on
+    /// purpose: a cold first run provisions native audio deps (downloads bass.dll, up to a 30s
+    /// HTTP timeout) BEFORE opening the pipe, so the old 10s ceiling killed the host mid-download
+    /// and surfaced "connection timed out" on first run (issue #4 — works once cached, which is
+    /// why already-provisioned machines never see it). A healthy/cached start still connects in
+    /// well under a second. The adopt path uses its own 90s default (see AttachAsync).
+    /// </summary>
+    private static readonly TimeSpan FirstLaunchConnectTimeout = TimeSpan.FromSeconds(60);
+
     private sealed record AudioHostLaunchContext(
         int ParentProcessId,
         string SessionId,
@@ -127,6 +150,25 @@ public sealed class AudioProcessManager : IAsyncDisposable
     /// True if the audio process is running and pipe is connected.
     /// </summary>
     public bool IsRunning => _process is { HasExited: false } && (_proxy?.IsConnected ?? false);
+
+    /// <summary>
+    /// Resolved path to the Wavee.AudioHost executable — the first existing candidate, or the
+    /// primary expected path if none was found. Surfaced for diagnostics bundles.
+    /// </summary>
+    public string AudioHostPath => _audioHostPath;
+
+    /// <summary>
+    /// True if <see cref="AudioHostPath"/> exists on disk. A missing executable is a common
+    /// "cannot connect to the audio engine" root cause. Surfaced for diagnostics bundles.
+    /// </summary>
+    public bool AudioHostExists => !string.IsNullOrEmpty(_audioHostPath) && File.Exists(_audioHostPath);
+
+    /// <summary>
+    /// Exit code of the most recent AudioHost process exit, or null if it has not exited / the
+    /// code could not be read. Exit code 3 is a deterministic native-dependency provisioning
+    /// failure. Surfaced for diagnostics bundles + failure messages.
+    /// </summary>
+    public int? LastExitCode => _lastExitCode;
 
     public AudioProcessManager(ILogger? logger = null)
     {
@@ -400,6 +442,10 @@ public sealed class AudioProcessManager : IAsyncDisposable
     {
         SetState(AudioProcessState.Connecting, "Starting audio engine...");
 
+        // TEST HOOK: simulate a startup failure (issue #4 repro) before any real launch.
+        if (!string.IsNullOrWhiteSpace(SimulateStartupFailure))
+            SimulateStartupFailureAndThrow(SimulateStartupFailure!);
+
         _pipeName = $"WaveeAudio_{Environment.ProcessId}_{Guid.NewGuid():N}";
         _launchContext = new AudioHostLaunchContext(
             Environment.ProcessId,
@@ -465,12 +511,12 @@ public sealed class AudioProcessManager : IAsyncDisposable
 
         try
         {
-            _logger?.LogDebug("Connecting to audio host pipe...");
-            await pipeClient.ConnectAsync((int)TimeSpan.FromSeconds(10).TotalMilliseconds, ct);
+            _logger?.LogDebug("Connecting to audio host pipe (timeout {Seconds}s)...", FirstLaunchConnectTimeout.TotalSeconds);
+            await pipeClient.ConnectAsync((int)FirstLaunchConnectTimeout.TotalMilliseconds, ct);
         }
         catch (TimeoutException)
         {
-            _logger?.LogError("Pipe connection timed out after 10s");
+            _logger?.LogError("Pipe connection timed out after {Seconds}s", FirstLaunchConnectTimeout.TotalSeconds);
             SetState(AudioProcessState.Failed, "Audio engine connection timed out");
             await KillProcessAsync();
             throw;
@@ -575,6 +621,7 @@ public sealed class AudioProcessManager : IAsyncDisposable
 
         var exitCode = -1;
         try { exitCode = _process?.ExitCode ?? -1; } catch { }
+        _lastExitCode = exitCode;
 
         _logger?.LogWarning("Audio host process exited (code={ExitCode}, restarts={Restarts}/{Max})",
             exitCode, _restartCount, MaxRestartAttempts);
@@ -656,6 +703,54 @@ public sealed class AudioProcessManager : IAsyncDisposable
         {
             _logger?.LogDebug(ex, "Error scanning native-deps failure markers");
             return null;
+        }
+    }
+
+    // ── TEST HOOK: simulated startup failure (remove before shipping) ──
+
+    private void SimulateStartupFailureAndThrow(string mode)
+    {
+        _logger?.LogWarning("[SIMULATION] Forcing AudioHost startup failure (mode={Mode})", mode);
+        string message;
+        switch (mode.Trim().ToLowerInvariant())
+        {
+            case "timeout":
+                _lastExitCode = null;
+                message = "Audio engine connection timed out";
+                break;
+            case "missing-exe":
+                _lastExitCode = null;
+                message = $"Audio host not found: {_audioHostPath}";
+                break;
+            default: // "provisioning" (and any other value) — mimic the issue #4 native-dep failure
+                WriteSimulatedProvisioningMarker();
+                _lastExitCode = ProvisioningFailedExitCode;
+                message = "Windows x64 BASS setup failed: Download failed (network) [SIMULATED]. Check your connection and click Retry.";
+                break;
+        }
+        SetState(AudioProcessState.Failed, message);
+        SignalReadiness(false);
+        throw new InvalidOperationException($"[SIMULATION] AudioHost startup failure: {mode}");
+    }
+
+    /// <summary>Writes a native-dep failure marker (left on disk) so the diagnostics bundle picks it up.</summary>
+    private void WriteSimulatedProvisioningMarker()
+    {
+        try
+        {
+            var dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Wavee", "NativeDeps");
+            Directory.CreateDirectory(dir);
+            var json =
+                "{\"displayName\":\"Windows x64 BASS\",\"libraryName\":\"bass\"," +
+                "\"reason\":\"Download failed (network) [SIMULATED]\"," +
+                $"\"timestampUtc\":\"{DateTime.UtcNow:O}\",\"simulated\":true}}";
+            File.WriteAllText(Path.Combine(dir, "bass-win-x64.failure.json"), json);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "[SIMULATION] failed to write provisioning marker");
         }
     }
 


### PR DESCRIPTION
This hotfix bundles the original updater fix with the fixes + diagnostics for issue #4.

**Related to #4** (Surface Pro 11 / Snapdragon X Plus, ARM64). The touch behaviour is fixed; the audio-engine fix is a strong-but-unconfirmed candidate pending the reporter's logs, so #4 stays open (non-closing link) until confirmed.

---

## In-app updater finds new pre-releases (`/releases` endpoint)

**Why:** Published `v0.1.0-alpha.2` but the in-app **Check for update** showed *UpToDate*. Root cause: `UpdateService` queried GitHub's `/releases/latest`, which excludes pre-releases. Every Wavee build is a pre-release, so that endpoint always 404'd → "no releases" → UpToDate.

**What:**
- Use the `/releases` list endpoint (includes pre-releases) and pick the highest-version non-draft release for the channel.
- Added a `considered` count + no-update reason to the update log.

> Note: alpha.1 / alpha.2 ship the old broken updater and cannot self-update to this fix — a one-time manual install of a fixed build is required; auto-update works from there.

---

## Touch: stop drag-reorder hijacking touch scroll (#4)

`ReorderController` / `ManualDragAttachment` now ignore touch pointers, so a finger pan scrolls the queue / playlist / library lists instead of grabbing a row. Mouse, pen, and keyboard reorder are unchanged. New `PointerInput.IsTouch` helper — single-point fix across every track surface.

## Audio engine first-run resilience (likely #4 "cannot connect" cause)

Only reproduces on a **cold first run** — already-provisioned machines (incl. the maintainer's ARM device) never hit it:
- **Fresh-launch pipe connect timeout 10s → 60s.** A cold first run downloads `bass.dll` *before* opening the pipe; the old 10s ceiling killed the host mid-download → "Audio engine connection timed out". (The adopt path already used 90s.)
- **Native-dep provisioner retries transient network/HTTP failures** (3 attempts, backoff) instead of failing on the first blip.
- `AudioProcessManager` exposes `AudioHostPath` / `AudioHostExists` / `LastExitCode`.

## In-app diagnostics + reporting

- **Bundle is now complete:** `CrashReportPackager` includes the **AudioHost log** + **NativeDeps failure markers** (previously missing — the exact files needed to triage #4), reports **real OS/process architecture** (Arm64, not the old `Is64Bit*` "x64" mislabel), and adds an AudioHost section (path / exists / exit code / native caches).
- **`DiagnosticsReporter`** chooser: build zip → reveal in Explorer → **Report on GitHub** / **Email logs** / Open folder.
- Settings → About card relabeled **"Report a problem / export logs"** (en-US + ko-KR).
- Notifications gained an optional **secondary action**; the startup audio-failure toast and the play-time "engine down" toast now offer **Retry + Report a problem**.

## Windows Sandbox / no-GPU startup crash

`BootSplash` rendered a ComputeSharp/Win2D shader on the **cold-start path**, crashing GPU-less environments (Windows Sandbox) with an unloggable stowed exception (`0xc000027b` in `CoreMessagingXP`) before any handler runs. The splash is now a **static gradient**; `AnimatedHeroBackground` self-disables on render failure so other surfaces degrade instead of crashing.

---

## ⚠️ Before merge
- Remove the temporary failure-simulation hook (`WAVEE_SIMULATE_AUDIO_FAILURE` / `AudioProcessManager.SimulateStartupFailure` + the commented toggle in `AppLifecycleHelper`).
- Flip `Related to #4` → `Fixes #4` once the reporter confirms the audio fix (note: auto-closes only on merge to the default branch, not `experimental`).
