### PR TITLE
fix(#6): playback play-fails, nav E_FAIL & queue-storm on ARM64 + silent auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,3 +288,28 @@ jobs:
           # auto-publishes the pre-release for a fast tester loop.
           draft: ${{ needs.version.outputs.prerelease != 'true' }}
           prerelease: ${{ needs.version.outputs.prerelease == 'true' }}
+
+      - name: Update experimental-latest rolling release (auto-update channel)
+        if: needs.version.outputs.prerelease == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ROLLING=experimental-latest
+          # GitHub has no "latest pre-release" download alias, so the experimental
+          # .appinstaller auto-update channel points at a FIXED rolling release. Ensure it
+          # exists, drop its old versioned MSIX (so they don't accumulate), then upload this
+          # build's assets so the stable URLs always serve the newest version. The per-tag
+          # v<ver>-alpha.N release above stays as the changelog/history archive.
+          if ! gh release view "$ROLLING" >/dev/null 2>&1; then
+            gh release create "$ROLLING" \
+              --prerelease \
+              --title "Experimental (latest)" \
+              --notes "Rolling pointer to the newest experimental build, consumed by the .appinstaller auto-update channel. Managed by CI — do not delete."
+          fi
+          for asset in $(gh release view "$ROLLING" --json assets --jq '.assets[] | select(.name | endswith(".msix")) | .name'); do
+            gh release delete-asset "$ROLLING" "$asset" -y || true
+          done
+          ASSETS=$(find artifacts -type f \( -name '*.msix' -o -name '*.appinstaller' \))
+          gh release upload "$ROLLING" $ASSETS --clobber

--- a/signing/Generate-AppInstaller.ps1
+++ b/signing/Generate-AppInstaller.ps1
@@ -1,33 +1,38 @@
 #requires -Version 7.0
 <#
 .SYNOPSIS
-    Generates Wavee.appinstaller from the template, substituting the release
-    version + tag.
+    Generates per-architecture Wavee .appinstaller files from the template.
 
 .DESCRIPTION
-    Reads signing/Wavee.appinstaller.template, replaces ${VERSION} (4-part
-    numeric, e.g. 0.1.0.1001), ${TAG} (the GitHub tag without 'v', e.g.
-    0.1.0-alpha.1), and ${APPINSTALLER_URI}, then writes the resulting
-    Wavee.appinstaller to the OutputDirectory.
+    Emits ONE .appinstaller PER ARCHITECTURE (x64 + arm64) so that each arch's install
+    auto-updates from its own arch's MSIX — the previous single x64-only file left ARM64
+    installs unable to update.
 
-    Designed to be called from the release pipeline after MSIX signing.
+    Reads signing/Wavee.appinstaller.template and substitutes ${VERSION} (4-part numeric),
+    ${ARCH}, ${APPINSTALLER_URI} (the stable self-URL Windows polls), and ${MSIX_URI}.
+
+    Stable channel polls the /latest alias; experimental polls a fixed `experimental-latest`
+    rolling release whose assets the pipeline re-uploads each build (GitHub has no
+    "latest pre-release" alias). Designed to be called from the release pipeline after signing.
 
 .PARAMETER Tag
-    The git tag, with or without the leading 'v' (e.g. 'v0.1.0-alpha.1' or
-    '0.1.0-alpha.1'). The 4-part numeric Version is derived from this.
+    The git tag, with or without the leading 'v' (e.g. 'v0.1.0-alpha.1'). The 4-part numeric
+    version is derived from it via ConvertTo-WaveePackageVersion.
 
 .PARAMETER OutputDirectory
-    Where to write the resulting Wavee.appinstaller. Created if missing.
+    Where to write the resulting .appinstaller files. Created if missing.
+
+.PARAMETER Channel
+    'stable' -> Wavee.<arch>.appinstaller tracking the latest production release.
+    'experimental' -> Wavee.Experimental.<arch>.appinstaller tracking the rolling pre-release.
 
 .EXAMPLE
-    pwsh signing/Generate-AppInstaller.ps1 -Tag v0.1.0-alpha.1 -OutputDirectory ./artifacts
+    pwsh signing/Generate-AppInstaller.ps1 -Tag v0.1.0-alpha.1 -Channel experimental -OutputDirectory ./artifacts
 #>
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)] [string] $Tag,
     [Parameter(Mandatory)] [string] $OutputDirectory,
-    # 'stable' -> Wavee.appinstaller tracking the latest production release.
-    # 'experimental' -> Wavee.Experimental.appinstaller pinned to this pre-release.
     [ValidateSet('stable', 'experimental')] [string] $Channel = 'stable'
 )
 
@@ -42,32 +47,41 @@ if (-not (Test-Path $templatePath)) {
 
 $releaseVersion = ConvertTo-WaveePackageVersion -Tag $Tag
 $cleanTag = $releaseVersion.CleanTag
-$version = $releaseVersion.PackageVersion
-
-$fileName = if ($Channel -eq 'experimental') { 'Wavee.Experimental.appinstaller' } else { 'Wavee.appinstaller' }
-
-# Update-check URI baked into the .appinstaller:
-#  - stable: the 'latest release' alias always serves the newest production build.
-#  - experimental: GitHub has no 'latest pre-release' alias, so we pin to this
-#    release's asset. The build installs fine; seamless experimental -> next-
-#    experimental auto-update is a known limitation (testers grab the newest
-#    pre-release manually for now). See docs/superpowers/specs/2026-05-29-release-pipeline-design.md.
-$appInstallerUri = if ($Channel -eq 'experimental') {
-    "https://github.com/christosk92/WaveeMusic/releases/download/v$cleanTag/$fileName"
-} else {
-    "https://github.com/christosk92/WaveeMusic/releases/latest/download/$fileName"
-}
+$version  = $releaseVersion.PackageVersion
 
 if (-not (Test-Path $OutputDirectory)) {
     New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
 }
 
-$content = Get-Content -Raw -Path $templatePath
-$content = $content.Replace('${VERSION}', $version)
-$content = $content.Replace('${TAG}', $cleanTag)
-$content = $content.Replace('${APPINSTALLER_URI}', $appInstallerUri)
+$template = Get-Content -Raw -Path $templatePath
+$repo = 'https://github.com/christosk92/WaveeMusic/releases'
 
-$outputPath = Join-Path $OutputDirectory $fileName
-Set-Content -Path $outputPath -Value $content -Encoding utf8
+foreach ($arch in @('x64', 'arm64')) {
+    $msixName = "Wavee.UI.WinUI_${version}_${arch}.msix"
 
-Write-Host "Generated $outputPath (Version=$version, Tag=$cleanTag, Channel=$Channel)"
+    if ($Channel -eq 'experimental') {
+        # GitHub has no "latest pre-release" download alias, so experimental polls a fixed
+        # rolling release whose assets are re-uploaded each build (stable URL, moving content).
+        $fileName        = "Wavee.Experimental.$arch.appinstaller"
+        $appInstallerUri = "$repo/download/experimental-latest/$fileName"
+        $msixUri         = "$repo/download/experimental-latest/$msixName"
+    }
+    else {
+        # Stable polls the /latest alias (always the newest published production release).
+        $fileName        = "Wavee.$arch.appinstaller"
+        $appInstallerUri = "$repo/latest/download/$fileName"
+        $msixUri         = "$repo/download/v$cleanTag/$msixName"
+    }
+
+    # .NET strings are immutable, so each Replace returns a new string and $template
+    # stays pristine for the next architecture in the loop.
+    $content = $template
+    $content = $content.Replace('${VERSION}', $version)
+    $content = $content.Replace('${ARCH}', $arch)
+    $content = $content.Replace('${APPINSTALLER_URI}', $appInstallerUri)
+    $content = $content.Replace('${MSIX_URI}', $msixUri)
+
+    $outputPath = Join-Path $OutputDirectory $fileName
+    Set-Content -Path $outputPath -Value $content -Encoding utf8
+    Write-Host "Generated $outputPath (Version=$version, Arch=$arch, Channel=$Channel)"
+}

--- a/signing/Wavee.appinstaller.template
+++ b/signing/Wavee.appinstaller.template
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  WaveeMusic .appinstaller manifest. The build pipeline substitutes ${VERSION}
-  with the MSIX package version (e.g. 0.1.0.1001), ${TAG} with the release tag,
-  and ${APPINSTALLER_URI} with the update-channel URL.
+  WaveeMusic .appinstaller manifest. signing/Generate-AppInstaller.ps1 emits ONE file
+  PER ARCHITECTURE and substitutes:
+    ${VERSION}          the 4-part MSIX package version (e.g. 0.1.0.1003)
+    ${ARCH}             x64 | arm64
+    ${APPINSTALLER_URI} the STABLE self-URL Windows polls for updates
+    ${MSIX_URI}         the download URL for this arch's signed MSIX
 
-  Stable releases use /latest/download for appinstaller update checks.
-  Prerelease alpha/beta tags use the exact tag URL so experimental drafts do
-  not accidentally bind to the stable update channel.
+  Stable releases poll /latest/download (a moving alias). Experimental builds poll a fixed
+  `experimental-latest` rolling release (GitHub has no "latest pre-release" alias), whose
+  assets are re-uploaded every build so the URL stays stable while the content moves forward.
 -->
 <AppInstaller Version="${VERSION}"
               Uri="${APPINSTALLER_URI}"
@@ -15,11 +18,15 @@
   <MainPackage Name="4f5ca249-aa41-4d46-84ce-62b6098fdb06"
                Version="${VERSION}"
                Publisher="CN=cproducts, O=cproducts, L=Utrecht, S=Utrecht, C=NL"
-               Uri="https://github.com/christosk92/WaveeMusic/releases/download/v${TAG}/Wavee.UI.WinUI_${VERSION}_x64.msix"
-               ProcessorArchitecture="x64" />
+               Uri="${MSIX_URI}"
+               ProcessorArchitecture="${ARCH}" />
 
+  <!-- Silent auto-update: Windows App Installer checks on launch (no prompt) and via an
+       ~8h background task, silently downloads + stages the new MSIX, and applies it on the
+       next restart. The app surfaces a "restart to update" nudge via
+       Package.CheckUpdateAvailabilityAsync (no package-management capability needed). -->
   <UpdateSettings>
-    <OnLaunch HoursBetweenUpdateChecks="24" ShowPrompt="false" />
+    <OnLaunch HoursBetweenUpdateChecks="8" ShowPrompt="false" />
     <AutomaticBackgroundTask />
   </UpdateSettings>
 

--- a/src/Wavee.UI.WinUI/Controls/Settings/AboutSettingsSection.xaml
+++ b/src/Wavee.UI.WinUI/Controls/Settings/AboutSettingsSection.xaml
@@ -29,6 +29,24 @@
                 </StackPanel>
 
                 <TextBlock x:Uid="Controls_Settings_AboutSettingsSection__TextBlock_2" Text="Updates" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,8" Tag="updates"/>
+
+                <!-- Shown once Windows App Installer has silently downloaded + staged a newer
+                     MSIX via the .appinstaller channel (IUpdateService.IsRestartUpdateReady).
+                     "Restart now" relaunches the process so Windows swaps in the new version. -->
+                <InfoBar IsOpen="{x:Bind ViewModel.UpdateService.IsRestartUpdateReady, Mode=OneWay}"
+                         IsClosable="False"
+                         Severity="Success"
+                         Title="{x:Bind RestartReadyTitle}"
+                         Message="{x:Bind RestartReadyMessage}"
+                         Margin="0,0,0,12"
+                         Tag="updates">
+                    <InfoBar.ActionButton>
+                        <Button Content="{x:Bind RestartNowLabel}"
+                                Style="{ThemeResource AccentButtonStyle}"
+                                Click="RestartToUpdate_Click"/>
+                    </InfoBar.ActionButton>
+                </InfoBar>
+
                 <controls:SettingsExpander x:Uid="Controls_Settings_AboutSettingsSection__SettingsExpander_3" Header="Check for updates"
                                            Description="{x:Bind ViewModel.UpdateService.Status, Mode=OneWay}"
                                            Tag="updates">

--- a/src/Wavee.UI.WinUI/Controls/Settings/AboutSettingsSection.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Settings/AboutSettingsSection.xaml.cs
@@ -256,10 +256,27 @@ public sealed partial class AboutSettingsSection : UserControl, ISettingsSearchF
     public SettingsViewModel ViewModel { get; }
     public ObservableCollection<ThirdPartyNoticeItem> ThirdPartyNotices => s_thirdPartyNotices;
 
+    // Localized strings for the "restart to apply staged update" InfoBar. These share the
+    // Update_Restart* resource keys with the equivalent notification raised by UpdateService,
+    // so the wording stays in one place across both surfaces.
+    public string RestartReadyTitle => AppLocalization.GetString("Update_RestartReadyTitle");
+    public string RestartReadyMessage => AppLocalization.GetString("Update_RestartReadyMessage");
+    public string RestartNowLabel => AppLocalization.GetString("Update_RestartNow");
+
     public AboutSettingsSection(SettingsViewModel viewModel)
     {
         ViewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
         InitializeComponent();
+        Loaded += OnAboutLoaded;
+    }
+
+    private async void OnAboutLoaded(object sender, RoutedEventArgs e)
+    {
+        // Re-check whether the background update task staged a newer MSIX while the app has been
+        // running, so the "restart to apply" InfoBar can appear without waiting for the next
+        // launch. Entered on the UI thread, so the property/toast update needs no marshalling.
+        if (ViewModel.UpdateService is { } updateService)
+            await updateService.CheckPackageUpdateAsync();
     }
 
     public void ApplySearchFilter(string? groupKey)
@@ -291,6 +308,12 @@ public sealed partial class AboutSettingsSection : UserControl, ISettingsSearchF
     private async void ReportProblem_Click(object sender, RoutedEventArgs e)
     {
         await DiagnosticsReporter.ReportAsync(XamlRoot);
+    }
+
+    private async void RestartToUpdate_Click(object sender, RoutedEventArgs e)
+    {
+        if (ViewModel.UpdateService is { } updateService)
+            await updateService.RestartToApplyUpdateAsync();
     }
 }
 

--- a/src/Wavee.UI.WinUI/Data/Contexts/ConnectCommandExecutor.cs
+++ b/src/Wavee.UI.WinUI/Data/Contexts/ConnectCommandExecutor.cs
@@ -785,6 +785,14 @@ internal sealed partial class ConnectCommandExecutor : IPlaybackCommandExecutor,
     public Task<PlaybackResult> PlayNextAsync(string trackUri, CancellationToken ct)
         => SendQueueMutationAsync(trackUri, atHead: true, ct);
 
+    /// <summary>Batch "Add to Queue" — one local queue mutation / one remote set_queue for all tracks.</summary>
+    public Task<PlaybackResult> AddToQueueBatchAsync(IReadOnlyList<string> trackUris, CancellationToken ct)
+        => SendQueueMutationBatchAsync(trackUris, atHead: false, ct);
+
+    /// <summary>Batch "Play Next" — one local queue mutation / one remote set_queue for all tracks.</summary>
+    public Task<PlaybackResult> PlayNextBatchAsync(IReadOnlyList<string> trackUris, CancellationToken ct)
+        => SendQueueMutationBatchAsync(trackUris, atHead: true, ct);
+
     /// <summary>
     /// Drag-reorder of one item within a queue bucket. Local playback only —
     /// the queue wire format (set_queue) cannot express post-context or
@@ -917,6 +925,79 @@ internal sealed partial class ConnectCommandExecutor : IPlaybackCommandExecutor,
     }
 
     /// <summary>
+    /// Batch counterpart of <see cref="SendQueueMutationAsync"/>: enqueues many tracks with a
+    /// SINGLE local queue mutation (one PutState) or a SINGLE remote set_queue — never one
+    /// command per track. Looping the single path floods the cluster publisher and freezes the
+    /// UI on a large selection (issue #4 follow-up).
+    /// </summary>
+    private async Task<PlaybackResult> SendQueueMutationBatchAsync(
+        IReadOnlyList<string> trackUris, bool atHead, CancellationToken ct)
+    {
+        var uris = new List<string>(trackUris?.Count ?? 0);
+        if (trackUris != null)
+            foreach (var u in trackUris)
+                if (!string.IsNullOrEmpty(u)) uris.Add(u);
+        if (uris.Count == 0)
+            return PlaybackResult.Success();
+        if (uris.Count == 1)
+            return await SendQueueMutationAsync(uris[0], atHead, ct).ConfigureAwait(false);
+
+        var target = GetTargetDeviceId();
+        var selfId = _session.Config.DeviceId;
+        var op = atHead ? "play_next" : "add_to_queue";
+        var isLocalRoute = string.IsNullOrEmpty(target) || target == selfId;
+
+        // LOCAL — one batch mutation on the orchestrator's queue (the orchestrator filters
+        // hidden / Spotify-disabled tracks once and publishes a single PutState).
+        if (isLocalRoute)
+        {
+            if (_localEngine is not Wavee.Audio.PlaybackOrchestrator orchestrator)
+            {
+                _logger?.LogWarning("[Executor] {Op} (batch): no local orchestrator — command dropped", op);
+                return PlaybackResult.Failure(
+                    PlaybackErrorKind.DeviceUnavailable,
+                    "No active device and no local playback engine available.");
+            }
+
+            try
+            {
+                _logger?.LogInformation("[Executor] {Op} (batch): routing LOCAL → {Count} tracks", op, uris.Count);
+                if (atHead)
+                    await orchestrator.PlayNextBatchAsync(uris, ct).ConfigureAwait(false);
+                else
+                    await orchestrator.EnqueueBatchAsync(uris, ct).ConfigureAwait(false);
+                return PlaybackResult.Success();
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "[Executor] {Op} (batch) FAILED (local engine threw)", op);
+                return PlaybackResult.Failure(PlaybackErrorKind.Unknown, ex.Message, ex);
+            }
+        }
+
+        // REMOTE — a single set_queue carrying all new tracks.
+        var body = BuildSetQueueBodyBatch(uris, atHead);
+        _logger?.LogInformation(
+            "[Executor] {Op} (batch): routing REMOTE set_queue → device={Target}, queueSize={Size}",
+            op, target, ((System.Collections.ICollection)body["next_tracks"]).Count);
+
+        var result = await _client.SendCommandAsync(
+            target,
+            "set_queue",
+            body,
+            waitForAck: false,
+            ackTimeout: TimeSpan.FromMilliseconds(2000),
+            ct: ct).ConfigureAwait(false);
+
+        if (result.IsSuccess)
+            _logger?.LogInformation("[Executor] {Op} (batch) OK (remote set_queue)", op);
+        else
+            _logger?.LogWarning("[Executor] {Op} (batch) FAILED (remote set_queue): {Error}", op, result.ErrorMessage);
+
+        return ToPlaybackResult(result);
+    }
+
+    /// <summary>
     /// Builds the JSON body for set_queue: a full snapshot of the remote
     /// user queue with the new track inserted at index 0 (Play Next) or
     /// appended at the tail (Add to Queue). Existing queued entries are
@@ -961,6 +1042,54 @@ internal sealed partial class ConnectCommandExecutor : IPlaybackCommandExecutor,
         {
             nextTracks.AddRange(existingQueued);
             nextTracks.Add(newEntry);
+        }
+
+        return new Dictionary<string, object>
+        {
+            ["next_tracks"] = nextTracks
+        };
+    }
+
+    /// <summary>Batch counterpart of <see cref="BuildSetQueueBody"/> — all new tracks in one snapshot.</summary>
+    private Dictionary<string, object> BuildSetQueueBodyBatch(IReadOnlyList<string> trackUris, bool atHead)
+    {
+        var clusterNext = _session.PlaybackState?.CurrentState.NextTracks
+                          ?? (IReadOnlyList<TrackReference>)System.Array.Empty<TrackReference>();
+
+        var existingQueued = new List<object>();
+        foreach (var t in clusterNext)
+        {
+            if (!t.IsUserQueued) continue;
+            existingQueued.Add(new Dictionary<string, object>
+            {
+                ["uri"] = t.Uri,
+                ["provider"] = "queue",
+                ["metadata"] = new Dictionary<string, string> { ["is_queued"] = "true" }
+            });
+        }
+
+        var newEntries = new List<object>(trackUris.Count);
+        for (var i = 0; i < trackUris.Count; i++)
+        {
+            newEntries.Add(new Dictionary<string, object>
+            {
+                ["uri"] = trackUris[i],
+                ["uid"] = $"q{i}",
+                ["provider"] = "queue",
+                ["metadata"] = new Dictionary<string, string> { ["is_queued"] = "true" }
+            });
+        }
+
+        var nextTracks = new List<object>(existingQueued.Count + newEntries.Count);
+        if (atHead)
+        {
+            nextTracks.AddRange(newEntries);
+            nextTracks.AddRange(existingQueued);
+        }
+        else
+        {
+            nextTracks.AddRange(existingQueued);
+            nextTracks.AddRange(newEntries);
         }
 
         return new Dictionary<string, object>

--- a/src/Wavee.UI.WinUI/Data/Contexts/IPlaybackCommandExecutor.cs
+++ b/src/Wavee.UI.WinUI/Data/Contexts/IPlaybackCommandExecutor.cs
@@ -26,6 +26,8 @@ internal interface IPlaybackCommandExecutor
     Task<PlaybackResult> SetVolumeAsync(int volumePercent, CancellationToken ct);
     Task<PlaybackResult> AddToQueueAsync(string trackUri, CancellationToken ct);
     Task<PlaybackResult> PlayNextAsync(string trackUri, CancellationToken ct);
+    Task<PlaybackResult> AddToQueueBatchAsync(IReadOnlyList<string> trackUris, CancellationToken ct);
+    Task<PlaybackResult> PlayNextBatchAsync(IReadOnlyList<string> trackUris, CancellationToken ct);
     Task<PlaybackResult> ReorderQueueAsync(Wavee.Audio.Queue.QueueReorderTarget target, int oldIndex, int newIndex, CancellationToken ct);
     Task<PlaybackResult> SkipToQueueItemAsync(int upcomingIndex, CancellationToken ct);
     Task<PlaybackResult> TransferPlaybackAsync(string deviceId, bool startPlaying, CancellationToken ct);

--- a/src/Wavee.UI.WinUI/Data/Contexts/PlaybackPromptService.cs
+++ b/src/Wavee.UI.WinUI/Data/Contexts/PlaybackPromptService.cs
@@ -29,6 +29,26 @@ internal sealed partial class PlaybackPromptService : IPlaybackPromptService
                 : PlayAction.PlayAndClear;
         }
 
+        // The prompt reads Window.Content / XamlRoot and shows a ContentDialog — both
+        // UI-thread-only. PlayContextAsync is frequently invoked from a background
+        // Task.Run (home cards, browse, hero), so a direct off-thread Window.Content read
+        // throws RPC_E_WRONG_THREAD and silently faults the play. Marshal the whole UI
+        // interaction onto the UI thread.
+        var dispatcher = MainWindow.Instance?.DispatcherQueue;
+        if (dispatcher is null || dispatcher.HasThreadAccess)
+            return await ShowPromptAndPersistAsync();
+
+        var tcs = new TaskCompletionSource<PlayAction>();
+        dispatcher.TryEnqueue(async () =>
+        {
+            try { tcs.SetResult(await ShowPromptAndPersistAsync()); }
+            catch (Exception) { tcs.TrySetResult(PlayAction.PlayAndClear); }
+        });
+        return await tcs.Task;
+    }
+
+    private async Task<PlayAction> ShowPromptAndPersistAsync()
+    {
         var xamlRoot = MainWindow.Instance.Content?.XamlRoot;
         if (xamlRoot == null) return PlayAction.PlayAndClear;
 

--- a/src/Wavee.UI.WinUI/Data/Contexts/PlaybackService.cs
+++ b/src/Wavee.UI.WinUI/Data/Contexts/PlaybackService.cs
@@ -279,6 +279,12 @@ internal sealed partial class PlaybackService : ObservableObject, IPlaybackServi
     public Task<PlaybackResult> PlayNextAsync(string trackUri, CancellationToken ct)
         => ExecuteWithRetryAsync(c => _executor.PlayNextAsync(trackUri, c), nameof(PlayNextAsync), ct, maxRetries: 0);
 
+    public Task<PlaybackResult> AddToQueueAsync(IReadOnlyList<string> trackUris, CancellationToken ct)
+        => ExecuteWithRetryAsync(c => _executor.AddToQueueBatchAsync(trackUris, c), nameof(AddToQueueAsync), ct, maxRetries: 0);
+
+    public Task<PlaybackResult> PlayNextAsync(IReadOnlyList<string> trackUris, CancellationToken ct)
+        => ExecuteWithRetryAsync(c => _executor.PlayNextBatchAsync(trackUris, c), nameof(PlayNextAsync), ct, maxRetries: 0);
+
     public Task<PlaybackResult> ReorderQueueAsync(
         Wavee.Audio.Queue.QueueReorderTarget target, int oldIndex, int newIndex, CancellationToken ct)
         => ExecuteWithRetryAsync(

--- a/src/Wavee.UI.WinUI/Data/Contexts/PlaybackStateService.cs
+++ b/src/Wavee.UI.WinUI/Data/Contexts/PlaybackStateService.cs
@@ -1833,14 +1833,15 @@ internal sealed partial class PlaybackStateService : ObservableObject, IPlayback
     public void AddToQueue(IEnumerable<string> trackIds)
     {
         var ids = trackIds as IReadOnlyList<string> ?? trackIds.ToList();
-        foreach (var trackId in ids)
+        if (ids.Count == 0) return;
+        // One batch call — the orchestrator enqueues all tracks in a single mutation and
+        // publishes ONE PutState. Looping the single overload here published one PutState per
+        // track, flooding the cluster publisher and freezing the UI on large lists (issue #4).
+        _logger?.LogInformation("[Cmd] AddToQueue (batch): {Count} tracks", ids.Count);
+        _ = _playbackService.AddToQueueAsync(ids).ContinueWith(t =>
         {
-            _logger?.LogInformation("[Cmd] AddToQueue: trackId={TrackId}", trackId);
-            _ = _playbackService.AddToQueueAsync(trackId).ContinueWith(t =>
-            {
-                if (t.IsFaulted) _logger?.LogError(t.Exception, "[Cmd] AddToQueue FAILED: trackId={TrackId}", trackId);
-            });
-        }
+            if (t.IsFaulted) _logger?.LogError(t.Exception, "[Cmd] AddToQueue (batch) FAILED: {Count} tracks", ids.Count);
+        });
         ShowQueueToast(ids.Count, playNext: false);
     }
 
@@ -1856,20 +1857,16 @@ internal sealed partial class PlaybackStateService : ObservableObject, IPlayback
 
     public void PlayNext(IEnumerable<string> trackIds)
     {
-        // Each PlayNextAsync inserts at the head of the user queue, so iterating in
-        // REVERSE order means the first track in `trackIds` lands at slot 0 (plays
-        // right after the current track), the second at slot 1, and so on — natural
-        // "play these next, in order" semantics for a bulk Play-Next bind.
         var ids = trackIds as IReadOnlyList<string> ?? trackIds.ToList();
-        for (var i = ids.Count - 1; i >= 0; i--)
+        if (ids.Count == 0) return;
+        // One batch call — the batch insert preserves order (first track plays next), so no
+        // reverse loop is needed, and the orchestrator publishes ONE PutState for the whole
+        // selection instead of one per track (issue #4: a 1777-track bulk add froze the UI).
+        _logger?.LogInformation("[Cmd] PlayNext (batch): {Count} tracks", ids.Count);
+        _ = _playbackService.PlayNextAsync(ids).ContinueWith(t =>
         {
-            var trackId = ids[i];
-            _logger?.LogInformation("[Cmd] PlayNext: trackId={TrackId}", trackId);
-            _ = _playbackService.PlayNextAsync(trackId).ContinueWith(t =>
-            {
-                if (t.IsFaulted) _logger?.LogError(t.Exception, "[Cmd] PlayNext FAILED: trackId={TrackId}", trackId);
-            });
-        }
+            if (t.IsFaulted) _logger?.LogError(t.Exception, "[Cmd] PlayNext (batch) FAILED: {Count} tracks", ids.Count);
+        });
         ShowQueueToast(ids.Count, playNext: true);
     }
 

--- a/src/Wavee.UI.WinUI/Helpers/Application/AppLifecycleHelper.cs
+++ b/src/Wavee.UI.WinUI/Helpers/Application/AppLifecycleHelper.cs
@@ -1091,12 +1091,6 @@ public static class AppLifecycleHelper
     {
         try
         {
-            // TEST: uncomment to simulate the issue #4 audio-engine failure so the
-            // failure toast (Retry + Report a problem) and the diagnostics bundle can be
-            // exercised. Re-comment (or clear) to restore real audio. Also settable via the
-            // WAVEE_SIMULATE_AUDIO_FAILURE env var ("provisioning" | "timeout" | "missing-exe").
-            //Wavee.AudioIpc.AudioProcessManager.SimulateStartupFailure = "provisioning";
-
             InitializeTrackMetadataEnricher(session, logger);
 
             _audioProcessManager = new Wavee.AudioIpc.AudioProcessManager(logger);

--- a/src/Wavee.UI.WinUI/Services/IUpdateService.cs
+++ b/src/Wavee.UI.WinUI/Services/IUpdateService.cs
@@ -23,5 +23,22 @@ public interface IUpdateService : INotifyPropertyChanged
     DistributionMode Distribution { get; }
     bool IsUpdateAvailable { get; }
 
+    /// <summary>
+    /// True once Windows App Installer has a newer package available/staged for this
+    /// <c>.appinstaller</c> install — the app should nudge the user to restart to apply it.
+    /// Always false for Store / Unpackaged installs.
+    /// </summary>
+    bool IsRestartUpdateReady { get; }
+
     Task CheckForUpdateAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Checks whether the installed MSIX has a newer version staged via its <c>.appinstaller</c>
+    /// (<c>Package.CheckUpdateAvailabilityAsync</c>). Shows a "restart to apply" nudge when ready.
+    /// No-op for Store / Unpackaged installs. Requires no package-management capability.
+    /// </summary>
+    Task CheckPackageUpdateAsync(CancellationToken ct = default);
+
+    /// <summary>Restarts the app so Windows applies the staged MSIX update.</summary>
+    Task RestartToApplyUpdateAsync();
 }

--- a/src/Wavee.UI.WinUI/Services/UpdateService.cs
+++ b/src/Wavee.UI.WinUI/Services/UpdateService.cs
@@ -36,6 +36,7 @@ public sealed partial class UpdateService : IUpdateService
     private string? _errorMessage;
     private DateTimeOffset? _lastChecked;
     private bool _isUpdateAvailable;
+    private bool _isRestartUpdateReady;
 
     public UpdateService(
         IHttpClientFactory httpClientFactory,
@@ -54,24 +55,39 @@ public sealed partial class UpdateService : IUpdateService
         // Restore last checked time
         _lastChecked = _settingsService.Settings.LastUpdateCheck;
 
-        // Fire-and-forget initial check after a short delay to let the app settle
+        // Fire-and-forget initial check after a short delay to let the app settle.
         _ = Task.Delay(TimeSpan.FromSeconds(5)).ContinueWith(async _ =>
         {
+            // GitHub-sourced version/changelog drives the Settings "what's new" surface
+            // regardless of how the app was installed.
             await CheckForUpdateAsync();
-            if (IsUpdateAvailable && Distribution != DistributionMode.Store)
+
+            switch (Distribution)
             {
-                _notificationService?.Show(new NotificationInfo
-                {
-                    Message = AppLocalization.Format("Update_AvailableMessage", LatestVersion),
-                    Severity = NotificationSeverity.Informational,
-                    AutoDismissAfter = TimeSpan.FromSeconds(8),
-                    ActionLabel = AppLocalization.GetString("Update_View"),
-                    Action = async () =>
+                case DistributionMode.Sideloaded:
+                    // Real auto-update path: Windows App Installer silently downloads + stages
+                    // the new MSIX from the .appinstaller; this nudges the user to restart.
+                    await CheckPackageUpdateAsync();
+                    break;
+                case DistributionMode.Unpackaged:
+                    // Dev build — no in-place update channel; point at the release page if newer.
+                    if (IsUpdateAvailable)
                     {
-                        if (ReleaseUrl != null)
-                            await Windows.System.Launcher.LaunchUriAsync(new Uri(ReleaseUrl));
+                        _notificationService?.Show(new NotificationInfo
+                        {
+                            Message = AppLocalization.Format("Update_AvailableMessage", LatestVersion),
+                            Severity = NotificationSeverity.Informational,
+                            AutoDismissAfter = TimeSpan.FromSeconds(8),
+                            ActionLabel = AppLocalization.GetString("Update_View"),
+                            Action = async () =>
+                            {
+                                if (ReleaseUrl != null)
+                                    await Windows.System.Launcher.LaunchUriAsync(new Uri(ReleaseUrl));
+                            }
+                        });
                     }
-                });
+                    break;
+                // Store: the Microsoft Store handles updates; no in-app nudge.
             }
         }, TaskScheduler.Default);
     }
@@ -126,6 +142,12 @@ public sealed partial class UpdateService : IUpdateService
     {
         get => _isUpdateAvailable;
         private set => SetField(ref _isUpdateAvailable, value);
+    }
+
+    public bool IsRestartUpdateReady
+    {
+        get => _isRestartUpdateReady;
+        private set => SetField(ref _isRestartUpdateReady, value);
     }
 
     public async Task CheckForUpdateAsync(CancellationToken ct = default)
@@ -233,6 +255,92 @@ public sealed partial class UpdateService : IUpdateService
         {
             _checkLock.Release();
         }
+    }
+
+    public async Task CheckPackageUpdateAsync(CancellationToken ct = default)
+    {
+        // Only sideloaded (.appinstaller) installs have a Windows-managed update channel.
+        // Store updates itself; unpackaged dev builds have no package at all.
+        if (Distribution != DistributionMode.Sideloaded)
+            return;
+
+        PackageUpdateAvailability availability;
+        try
+        {
+            // CheckUpdateAvailabilityAsync inspects the install's .appinstaller channel and
+            // reports whether App Installer has staged (or can fetch) a newer package. It needs
+            // NO package-management capability — unlike the PackageManager add/stage APIs.
+            var result = await Package.Current.CheckUpdateAvailabilityAsync();
+            ct.ThrowIfCancellationRequested();
+            availability = result.Availability;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Throws when the package wasn't installed from an .appinstaller, or the channel is
+            // unreachable. Treat as "no in-place update" — the GitHub check still covers "what's new".
+            _logger?.LogDebug(ex, "CheckUpdateAvailabilityAsync failed (treating as no update)");
+            return;
+        }
+
+        var ready = availability is PackageUpdateAvailability.Available
+                                 or PackageUpdateAvailability.Required;
+        if (!ready)
+        {
+            _logger?.LogDebug("Package update check: none staged (availability={Availability})", availability);
+            return;
+        }
+
+        if (IsRestartUpdateReady)
+            return; // already nudged this session
+
+        _logger?.LogInformation(
+            "MSIX update staged via .appinstaller; prompting restart (availability={Availability})",
+            availability);
+
+        // Setting IsRestartUpdateReady raises PropertyChanged that an x:Bind on the Settings
+        // About page consumes, and Show posts a toast — both touch XAML. This method is usually
+        // resumed on a threadpool thread (the post-launch check enters without a UI
+        // SynchronizationContext), so off-thread XAML access would throw RPC_E_WRONG_THREAD.
+        // Marshal to the UI thread (matches the documented hazard in SettingsViewModel).
+        var dispatcher = MainWindow.Instance?.DispatcherQueue;
+        if (dispatcher is null || dispatcher.HasThreadAccess)
+            ShowRestartReadyNudge();
+        else
+            dispatcher.TryEnqueue(ShowRestartReadyNudge);
+    }
+
+    private void ShowRestartReadyNudge()
+    {
+        IsRestartUpdateReady = true;
+        _notificationService?.Show(new NotificationInfo
+        {
+            Message = AppLocalization.GetString("Update_RestartReadyMessage"),
+            Severity = NotificationSeverity.Informational,
+            AutoDismissAfter = TimeSpan.FromSeconds(12),
+            ActionLabel = AppLocalization.GetString("Update_RestartNow"),
+            Action = RestartToApplyUpdateAsync
+        });
+    }
+
+    public Task RestartToApplyUpdateAsync()
+    {
+        try
+        {
+            // Full process restart so Windows applies the staged MSIX on relaunch. This is a
+            // hard process replacement (distinct from UiRestartCoordinator's UI-only restart) —
+            // on success it terminates the current process and never returns.
+            var reason = Microsoft.Windows.AppLifecycle.AppInstance.Restart(string.Empty);
+            _logger?.LogWarning("AppInstance.Restart returned without restarting ({Reason})", reason);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Restart to apply update failed");
+        }
+        return Task.CompletedTask;
     }
 
     private void ReportNoUpdate(string reason)

--- a/src/Wavee.UI.WinUI/Strings/en-US/Resources.resw
+++ b/src/Wavee.UI.WinUI/Strings/en-US/Resources.resw
@@ -1900,6 +1900,15 @@ Supports Markdown: **bold**, _italic_, `code`, - lists</value>
   <data name="Update_View" xml:space="preserve">
     <value>View</value>
   </data>
+  <data name="Update_RestartReadyTitle" xml:space="preserve">
+    <value>Update ready</value>
+  </data>
+  <data name="Update_RestartReadyMessage" xml:space="preserve">
+    <value>A new version of Wavee has been downloaded. Restart to apply it.</value>
+  </data>
+  <data name="Update_RestartNow" xml:space="preserve">
+    <value>Restart now</value>
+  </data>
   <data name="Connect_RequestingPairingCode" xml:space="preserve">
     <value>Requesting pairing code...</value>
   </data>

--- a/src/Wavee.UI.WinUI/Strings/ko-KR/Resources.resw
+++ b/src/Wavee.UI.WinUI/Strings/ko-KR/Resources.resw
@@ -1744,6 +1744,15 @@
   <data name="Update_View" xml:space="preserve">
     <value>보기</value>
   </data>
+  <data name="Update_RestartReadyTitle" xml:space="preserve">
+    <value>업데이트 준비됨</value>
+  </data>
+  <data name="Update_RestartReadyMessage" xml:space="preserve">
+    <value>새 버전의 Wavee가 다운로드되었습니다. 다시 시작하여 적용하세요.</value>
+  </data>
+  <data name="Update_RestartNow" xml:space="preserve">
+    <value>지금 다시 시작</value>
+  </data>
   <data name="Connect_RequestingPairingCode" xml:space="preserve">
     <value>페어링 코드를 요청하는 중...</value>
   </data>

--- a/src/Wavee.UI.WinUI/ViewModels/EpisodePageViewModel.cs
+++ b/src/Wavee.UI.WinUI/ViewModels/EpisodePageViewModel.cs
@@ -410,11 +410,13 @@ public sealed partial class EpisodePageViewModel : ObservableObject, ITabBarItem
         FullDescription = null;
         DescriptionHtml = null;
         ShareUrl = null;
-        Chapters.Clear();
+        // Resilient resets during navigation — raw Clear() on these bound rails throws
+        // COMException E_FAIL mid-layout (issue #6).
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(Chapters, []);
         OnPropertyChanged(nameof(HasChapters));
-        MoreFromShow.Clear();
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(MoreFromShow, []);
         OnPropertyChanged(nameof(HasMoreFromShow));
-        Comments.Clear();
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(Comments, []);
         _commentsNextPageToken = null;
         _commentsTotalCount = 0;
         CommentDraft = "";

--- a/src/Wavee.UI.WinUI/ViewModels/Home/HomeFeedViewModel.cs
+++ b/src/Wavee.UI.WinUI/ViewModels/Home/HomeFeedViewModel.cs
@@ -568,7 +568,9 @@ public sealed partial class HomeFeedViewModel : ObservableObject, IDisposable
     private async Task PopulateSectionsChunkedAsync(IList<HomeSection> ordered, int chunkSize = 4)
     {
         // Start from empty: we only call this when Sections.Count == 0, but guard anyway.
-        if (Sections.Count > 0) Sections.Clear();
+        // Resilient reset — a raw Clear() on the bound home shelf mid-layout can E_FAIL (issue #6).
+        if (Sections.Count > 0)
+            Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(Sections, []);
 
         var isDark = _isDarkThemeProvider();
 

--- a/src/Wavee.UI.WinUI/ViewModels/Playlist/PlaylistHeaderViewModel.cs
+++ b/src/Wavee.UI.WinUI/ViewModels/Playlist/PlaylistHeaderViewModel.cs
@@ -1221,7 +1221,9 @@ public sealed partial class PlaylistHeaderViewModel : ObservableObject
     {
         _lastCollaboratorSignature = null;
         SetShouldShowAddedByColumn(false);
-        Collaborators.Clear();
+        // Resilient reset during navigation (issue #6) — raw Clear() on the bound Collaborators
+        // list mid-layout throws COMException E_FAIL (the same hazard Dispose() below documents).
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(Collaborators, []);
         HasCollaborators = false;
         LatestInviteLink = null;
         PaletteBackdropBrush = null;

--- a/src/Wavee.UI.WinUI/ViewModels/Playlist/PlaylistMutationCoordinator.cs
+++ b/src/Wavee.UI.WinUI/ViewModels/Playlist/PlaylistMutationCoordinator.cs
@@ -443,7 +443,11 @@ public sealed partial class PlaylistMutationCoordinator : ObservableObject
     /// (recommendations + auto-trigger guard).</summary>
     public void ResetForNewPlaylist()
     {
-        _recommendedTracks.Clear();
+        // Resilient reset: a raw Clear() here runs synchronously during navigation while the
+        // bound ItemsRepeater is mid-layout, which throws COMException E_FAIL and hangs the
+        // page swap. ReplaceWith mutates the backing list then raises a Reset that retries on a
+        // Low-priority dispatcher tick if the control rejects it (same helper used at line ~398).
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(_recommendedTracks, []);
         HasRecommendedTracks = false;
         RecommendationsLoadFailed = false;
         _recommendationsAutoTriggeredFor = null;
@@ -451,6 +455,6 @@ public sealed partial class PlaylistMutationCoordinator : ObservableObject
 
     public void Dispose()
     {
-        _recommendedTracks.Clear();
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(_recommendedTracks, []);
     }
 }

--- a/src/Wavee.UI.WinUI/ViewModels/Playlist/PlaylistTrackListViewModel.cs
+++ b/src/Wavee.UI.WinUI/ViewModels/Playlist/PlaylistTrackListViewModel.cs
@@ -1422,7 +1422,9 @@ public sealed partial class PlaylistTrackListViewModel
         HasAnyAddedAt = false;
 
         _suppressSessionSignal = true;
-        SessionControlChips.Clear();
+        // Resilient reset — raw Clear() on a bound collection during navigation throws
+        // COMException E_FAIL mid-layout (issue #6). ReplaceWith raises a Reset that retries.
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(SessionControlChips, []);
         SelectedSessionControlChip = null;
         _suppressSessionSignal = false;
         OnPropertyChanged(nameof(HasSessionControlChips));
@@ -1431,7 +1433,7 @@ public sealed partial class PlaylistTrackListViewModel
         _sessionSignalCts = null;
 
         if (FilteredTracks.Count > 0)
-            FilteredTracks.Clear();
+            Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(FilteredTracks, []);
 
         TracksChanged?.Invoke(this, EventArgs.Empty);
     }
@@ -1442,12 +1444,15 @@ public sealed partial class PlaylistTrackListViewModel
     public void Hibernate()
     {
         Deactivate();
-        FilteredTracks.Clear();
+        // Cached-page hibernate: raise a (resilient) Reset so the ItemsControl releases its
+        // realized containers; a raw Clear() here can E_FAIL while the page's surfaces are
+        // being dropped by the nav cache (issue #6).
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(FilteredTracks, []);
         _allTracks = new List<PlaylistTrackDto>();
         ShowOnlyVideoTracks = false;
         NotifyVideoFilterProperties();
         _suppressSessionSignal = true;
-        SessionControlChips.Clear();
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(SessionControlChips, []);
         SelectedSessionControlChip = null;
         _suppressSessionSignal = false;
         OnPropertyChanged(nameof(HasSessionControlChips));
@@ -1473,10 +1478,13 @@ public sealed partial class PlaylistTrackListViewModel
     {
         _disposed = true;
         Deactivate();
-        FilteredTracks.Clear();
+        // Permanent teardown: clear the backing lists WITHOUT raising CollectionChanged — the
+        // XAML may already have detached its handlers, and raising then can touch torn-down
+        // UIElementCollection instances (issue #6; same hazard PlaylistHeaderViewModel.Dispose notes).
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ClearWithoutNotify(FilteredTracks);
         _allTracks = new List<PlaylistTrackDto>();
-        SessionControlChips.Clear();
-        EmptyPlaylistGenreItems.Clear();
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ClearWithoutNotify(SessionControlChips);
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ClearWithoutNotify(EmptyPlaylistGenreItems);
         SelectedItems = Array.Empty<object>();
         SelectedSessionControlChip = null;
     }

--- a/src/Wavee.UI.WinUI/ViewModels/ProfileViewModel.cs
+++ b/src/Wavee.UI.WinUI/ViewModels/ProfileViewModel.cs
@@ -302,11 +302,13 @@ public sealed partial class ProfileViewModel : Wavee.UI.ViewModels.Helpers.Track
         ProfileImageUrl = null;
         PageBleedBrush = null;
 
-        _recentArtists.Clear();
-        _publicPlaylists.Clear();
-        _followingArtists.Clear();
-        _topTracks.Clear();
-        _topTrackItems.Clear();
+        // Resilient resets on hibernate — raw Clear() on these bound profile collections can
+        // E_FAIL while the cached page's surfaces are dropped by the nav cache (issue #6).
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(_recentArtists, []);
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(_publicPlaylists, []);
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(_followingArtists, []);
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(_topTracks, []);
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(_topTrackItems, []);
     }
 
     public void ResumeFromHibernate()

--- a/src/Wavee.UI.WinUI/ViewModels/SearchViewModel.cs
+++ b/src/Wavee.UI.WinUI/ViewModels/SearchViewModel.cs
@@ -394,12 +394,14 @@ public sealed partial class SearchViewModel : ObservableObject, ITabBarItemConte
 
     private void DispatchResults(IReadOnlyList<SearchResultItem> items)
     {
-        Tracks.Clear();
-        AdaptedTracks.Clear();
-        Artists.Clear();
-        Albums.Clear();
-        Playlists.Clear();
-        Sections.Clear();
+        // Resilient resets — raw Clear() on these bound result collections can E_FAIL when the
+        // search page rebinds mid-layout (issue #6). The repopulating Adds below are unchanged.
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(Tracks, []);
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(AdaptedTracks, []);
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(Artists, []);
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(Albums, []);
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(Playlists, []);
+        Wavee.UI.WinUI.Extensions.ObservableCollectionExtensions.ReplaceWith(Sections, []);
 
         foreach (var item in items)
         {

--- a/src/Wavee.UI/Contracts/IPlaybackService.cs
+++ b/src/Wavee.UI/Contracts/IPlaybackService.cs
@@ -94,6 +94,19 @@ public interface IPlaybackService : INotifyPropertyChanged
     Task<PlaybackResult> PlayNextAsync(string trackUri, CancellationToken ct = default);
 
     /// <summary>
+    /// Batch "Add to Queue" — appends many tracks with a SINGLE queue mutation / PutState.
+    /// Prefer this over looping the single overload for multi-selections: per-track publishing
+    /// floods the cluster publisher and freezes the UI on large lists (issue #4 follow-up).
+    /// </summary>
+    Task<PlaybackResult> AddToQueueAsync(IReadOnlyList<string> trackUris, CancellationToken ct = default);
+
+    /// <summary>
+    /// Batch "Play Next" — inserts many tracks at the head of the user queue (order preserved)
+    /// with a SINGLE queue mutation / PutState.
+    /// </summary>
+    Task<PlaybackResult> PlayNextAsync(IReadOnlyList<string> trackUris, CancellationToken ct = default);
+
+    /// <summary>
     /// Drag-reorder of one item within a single queue bucket. Local playback
     /// only — rejected when playing on a remote device.
     /// </summary>

--- a/src/Wavee.UI/Services/DragDrop/Handlers/EnqueueTracksHandler.cs
+++ b/src/Wavee.UI/Services/DragDrop/Handlers/EnqueueTracksHandler.cs
@@ -21,27 +21,20 @@ public static class EnqueueTracksHandler
         if (ctx.Payload is not TrackDragPayload tracks) return DropResult.NoHandler;
 
         var playNext = (ctx.Modifiers & DropModifiers.Shift) != 0;
-        var added = 0;
+        var uris = tracks.TrackUris;
+        if (uris.Count == 0) return DropResult.Ok(0, "No tracks");
         try
         {
-            // Walk in reverse for "Play next" so the visible order matches the
-            // payload order (each insertion at the head pushes the previous one down).
+            // One batch call — the orchestrator enqueues every track in a single mutation and
+            // publishes ONE PutState. Looping the single overload published one PutState per
+            // track, flooding the cluster publisher and freezing the UI on a big selection
+            // (issue #4). The batch insert preserves payload order for "Play next", so no reverse.
             if (playNext)
-            {
-                for (var i = tracks.TrackUris.Count - 1; i >= 0; i--)
-                {
-                    await playback.PlayNextAsync(tracks.TrackUris[i], ct).ConfigureAwait(false);
-                    added++;
-                }
-            }
+                await playback.PlayNextAsync(uris, ct).ConfigureAwait(false);
             else
-            {
-                foreach (var uri in tracks.TrackUris)
-                {
-                    await playback.AddToQueueAsync(uri, ct).ConfigureAwait(false);
-                    added++;
-                }
-            }
+                await playback.AddToQueueAsync(uris, ct).ConfigureAwait(false);
+
+            var added = uris.Count;
             var verb = playNext ? "Playing next" : "Added to queue";
             return DropResult.Ok(added, $"{verb}: {added} track{(added == 1 ? string.Empty : "s")}");
         }

--- a/src/Wavee/Audio/PlaybackOrchestrator.cs
+++ b/src/Wavee/Audio/PlaybackOrchestrator.cs
@@ -801,6 +801,78 @@ public sealed partial class PlaybackOrchestrator : IPlaybackEngine, IAsyncDispos
     }
 
     /// <summary>
+    /// Batch "Play Next" — inserts all tracks at the head of the user queue with a SINGLE
+    /// queue mutation + SINGLE <see cref="PublishQueueState"/>. Looping <see cref="PlayNextAsync"/>
+    /// per track publishes one PutState each, which floods the cluster publisher and freezes the
+    /// UI on a large selection (issue #4 follow-up).
+    /// </summary>
+    public Task PlayNextBatchAsync(IReadOnlyList<string> trackUris, CancellationToken ct = default)
+    {
+        var tracks = BuildQueueTracksForBatch(trackUris, HiddenFilterSurface.PlayNext);
+        if (tracks.Count == 0)
+            return Task.CompletedTask;
+
+        _queue.PlayNextBatch(tracks);
+        _logger?.LogInformation("Orchestrator: PlayNext batch → {Count} tracks", tracks.Count);
+        PublishQueueState();
+        PrimeQueueContinuationIfNeeded();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Batch "Add to Queue" — appends all tracks to the post-context bucket with a SINGLE
+    /// queue mutation + SINGLE <see cref="PublishQueueState"/> (see <see cref="PlayNextBatchAsync"/>).
+    /// </summary>
+    public Task EnqueueBatchAsync(IReadOnlyList<string> trackUris, CancellationToken ct = default)
+    {
+        var tracks = BuildQueueTracksForBatch(trackUris, HiddenFilterSurface.AddToQueue);
+        if (tracks.Count == 0)
+            return Task.CompletedTask;
+
+        _queue.EnqueueAfterContextBatch(tracks);
+        _logger?.LogInformation("Orchestrator: Enqueue batch (post-context) → {Count} tracks", tracks.Count);
+        PublishQueueState();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Filters a batch of URIs once (empty / Spotify-disabled / hidden) and projects the
+    /// survivors to <see cref="QueueTrack"/>. Emits at most one error event and one
+    /// hidden-filtered event for the whole batch — never one per track.
+    /// </summary>
+    private List<QueueTrack> BuildQueueTracksForBatch(IReadOnlyList<string> trackUris, HiddenFilterSurface surface)
+    {
+        var result = new List<QueueTrack>(trackUris.Count);
+        var hidden = 0;
+        var spotifyBlocked = 0;
+        foreach (var uri in trackUris)
+        {
+            if (string.IsNullOrEmpty(uri))
+                continue;
+            if (!_localSpotifyPlaybackEnabled && SpotifyPlaybackCapabilities.IsSpotifyAudioPlaybackUri(uri))
+            {
+                spotifyBlocked++;
+                continue;
+            }
+            if (_contentFilter?.IsTrackHidden(uri) == true)
+            {
+                hidden++;
+                continue;
+            }
+            result.Add(new QueueTrack(uri));
+        }
+
+        if (spotifyBlocked > 0)
+        {
+            _logger?.LogWarning("Batch enqueue: {Count} Spotify track(s) blocked (local Spotify playback disabled)", spotifyBlocked);
+            _errorSubject.OnNext(new PlaybackError(PlaybackErrorType.Unknown, SpotifyPlaybackCapabilities.DisabledMessage));
+        }
+        if (hidden > 0)
+            _hiddenTracksFilteredSubject.OnNext(new HiddenTracksFilteredEvent(surface, hidden));
+        return result;
+    }
+
+    /// <summary>
     /// Drag-reorder of one item within a single queue bucket. Publishes the new
     /// queue state (cluster + UI) only if the move was actually applied.
     /// </summary>

--- a/src/Wavee/Audio/Queue/PlaybackQueue.cs
+++ b/src/Wavee/Audio/Queue/PlaybackQueue.cs
@@ -738,6 +738,56 @@ public sealed class PlaybackQueue : IDisposable
     }
 
     /// <summary>
+    /// Batch "Play Next" — inserts all tracks at the HEAD of the user queue, preserving
+    /// their order (first item plays next), with a SINGLE <see cref="StateChanged"/>
+    /// notification. Use this instead of calling <see cref="PlayNext"/> in a loop: each
+    /// single call publishes a full PutState, so a large multi-selection floods the
+    /// cluster publisher and freezes the UI.
+    /// </summary>
+    public void PlayNextBatch(IEnumerable<QueueTrack> tracks)
+    {
+        var staged = new List<QueueTrack>();
+        lock (_lock)
+        {
+            foreach (var track in tracks)
+            {
+                var queueUid = $"q{_queueUidCounter++}";
+                staged.Add(track with { Uid = queueUid, IsUserQueued = true, IsPostContext = false });
+            }
+            if (staged.Count == 0) return;
+            _userQueue.InsertRange(0, staged);
+            _logger?.LogDebug("Play Next (batch): inserted {Count} at head of user queue, queue size={Size}",
+                staged.Count, _userQueue.Count);
+        }
+
+        NotifyStateChanged();
+    }
+
+    /// <summary>
+    /// Batch "Add to Queue" — appends all tracks to the post-context bucket in order,
+    /// with a SINGLE <see cref="StateChanged"/> notification (see
+    /// <see cref="PlayNextBatch"/> for why per-track loops are avoided).
+    /// </summary>
+    public void EnqueueAfterContextBatch(IEnumerable<QueueTrack> tracks)
+    {
+        var added = 0;
+        lock (_lock)
+        {
+            foreach (var track in tracks)
+            {
+                var uid = $"p{_postContextUidCounter++}";
+                _postContextQueue.Add(track with { Uid = uid, IsUserQueued = true, IsPostContext = true });
+                added++;
+            }
+            if (added == 0) return;
+            _logger?.LogDebug("Add to Queue (batch): appended {Count} to post-context, bucket size={Size}",
+                added, _postContextQueue.Count);
+        }
+
+        NotifyStateChanged();
+    }
+
+    /// <summary>
     /// Removes a track from the user queue.
     /// </summary>
     /// <param name="index">Index in user queue to remove.</param>

--- a/src/Wavee/AudioIpc/AudioProcessManager.cs
+++ b/src/Wavee/AudioIpc/AudioProcessManager.cs
@@ -35,18 +35,6 @@ public sealed class AudioProcessManager : IAsyncDisposable
     /// </summary>
     public static bool UseVerboseLogging { get; set; }
 
-    /// <summary>
-    /// TEST HOOK — when non-empty, the next AudioHost launch is short-circuited into a
-    /// simulated startup failure so the failure UX (Retry + Report a problem) and the
-    /// diagnostics bundle can be exercised without a real audio fault. Defaults from the
-    /// <c>WAVEE_SIMULATE_AUDIO_FAILURE</c> environment variable. Recognized values:
-    /// <c>"provisioning"</c> (default — mimics the issue #4 native-dependency failure:
-    /// exit code 3 + a bass-win-x64.failure.json marker), <c>"timeout"</c>, <c>"missing-exe"</c>.
-    /// Leave null/empty in production. Remove before shipping.
-    /// </summary>
-    public static string? SimulateStartupFailure { get; set; } =
-        Environment.GetEnvironmentVariable("WAVEE_SIMULATE_AUDIO_FAILURE");
-
     private readonly ILogger? _logger;
     private readonly string _audioHostPath;
     private readonly CancellationTokenSource _cts = new();
@@ -442,10 +430,6 @@ public sealed class AudioProcessManager : IAsyncDisposable
     {
         SetState(AudioProcessState.Connecting, "Starting audio engine...");
 
-        // TEST HOOK: simulate a startup failure (issue #4 repro) before any real launch.
-        if (!string.IsNullOrWhiteSpace(SimulateStartupFailure))
-            SimulateStartupFailureAndThrow(SimulateStartupFailure!);
-
         _pipeName = $"WaveeAudio_{Environment.ProcessId}_{Guid.NewGuid():N}";
         _launchContext = new AudioHostLaunchContext(
             Environment.ProcessId,
@@ -703,54 +687,6 @@ public sealed class AudioProcessManager : IAsyncDisposable
         {
             _logger?.LogDebug(ex, "Error scanning native-deps failure markers");
             return null;
-        }
-    }
-
-    // ── TEST HOOK: simulated startup failure (remove before shipping) ──
-
-    private void SimulateStartupFailureAndThrow(string mode)
-    {
-        _logger?.LogWarning("[SIMULATION] Forcing AudioHost startup failure (mode={Mode})", mode);
-        string message;
-        switch (mode.Trim().ToLowerInvariant())
-        {
-            case "timeout":
-                _lastExitCode = null;
-                message = "Audio engine connection timed out";
-                break;
-            case "missing-exe":
-                _lastExitCode = null;
-                message = $"Audio host not found: {_audioHostPath}";
-                break;
-            default: // "provisioning" (and any other value) — mimic the issue #4 native-dep failure
-                WriteSimulatedProvisioningMarker();
-                _lastExitCode = ProvisioningFailedExitCode;
-                message = "Windows x64 BASS setup failed: Download failed (network) [SIMULATED]. Check your connection and click Retry.";
-                break;
-        }
-        SetState(AudioProcessState.Failed, message);
-        SignalReadiness(false);
-        throw new InvalidOperationException($"[SIMULATION] AudioHost startup failure: {mode}");
-    }
-
-    /// <summary>Writes a native-dep failure marker (left on disk) so the diagnostics bundle picks it up.</summary>
-    private void WriteSimulatedProvisioningMarker()
-    {
-        try
-        {
-            var dir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "Wavee", "NativeDeps");
-            Directory.CreateDirectory(dir);
-            var json =
-                "{\"displayName\":\"Windows x64 BASS\",\"libraryName\":\"bass\"," +
-                "\"reason\":\"Download failed (network) [SIMULATED]\"," +
-                $"\"timestampUtc\":\"{DateTime.UtcNow:O}\",\"simulated\":true}}";
-            File.WriteAllText(Path.Combine(dir, "bass-win-x64.failure.json"), json);
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogDebug(ex, "[SIMULATION] failed to write provisioning marker");
         }
     }
 

--- a/src/Wavee/Connect/PlaybackStateManager.cs
+++ b/src/Wavee/Connect/PlaybackStateManager.cs
@@ -86,6 +86,11 @@ public sealed class PlaybackStateManager : IAsyncDisposable
     // State publisher (bidirectional mode only)
     private AsyncWorker<PutStateRequest>? _statePublisher;
 
+    // Last published full-state snapshot (FormatStateSnapshot). Used to skip submitting a
+    // PutState identical to the previous one — a defensive backstop against per-mutation
+    // publish storms (issue #4). Only ever suppresses literal duplicate re-emissions.
+    private string? _lastPublishKey;
+
     // PutState debounce — position-only updates are debounced, critical changes flush immediately
     private CancellationTokenSource? _debounceCts;
     private PlaybackState? _pendingState;
@@ -961,6 +966,19 @@ public sealed class PlaybackStateManager : IAsyncDisposable
 
         try
         {
+            // Defense-in-depth dedup (issue #4): skip a PutState whose full snapshot is identical
+            // to the one we just published. FormatStateSnapshot captures status / track / position /
+            // queue-revision / timestamp — all of which change on any genuine update — so this only
+            // ever suppresses literal duplicate re-emissions (the storm signature), never a real
+            // change. Backstops any future per-mutation storm before the clone + cluster round-trip.
+            var publishKey = FormatStateSnapshot(state);
+            if (string.Equals(publishKey, _lastPublishKey, StringComparison.Ordinal))
+            {
+                _logger?.LogTrace("PutState SKIP (identical to last published)");
+                return;
+            }
+            _lastPublishKey = publishKey;
+
             var now = (ulong)(_session?.Clock.NowMs ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
 
             // Track when playback started (reset on track change or when becoming active)

--- a/src/Wavee/Connect/PlaybackStateManager.cs
+++ b/src/Wavee/Connect/PlaybackStateManager.cs
@@ -966,18 +966,18 @@ public sealed class PlaybackStateManager : IAsyncDisposable
 
         try
         {
-            // Defense-in-depth dedup (issue #4): skip a PutState whose full snapshot is identical
-            // to the one we just published. FormatStateSnapshot captures status / track / position /
-            // queue-revision / timestamp — all of which change on any genuine update — so this only
-            // ever suppresses literal duplicate re-emissions (the storm signature), never a real
-            // change. Backstops any future per-mutation storm before the clone + cluster round-trip.
-            var publishKey = FormatStateSnapshot(state);
+            // Defense-in-depth dedup (issue #6): skip a PutState whose full snapshot is identical to
+            // the one we last SUBMITTED. The key must capture everything that affects the wire body —
+            // FormatStateSnapshot omits the queue, so QueueRevision is appended explicitly; otherwise
+            // an add-to-queue (same track/pos/status, only the queue changed) would be wrongly deduped
+            // and never reach the cluster. The key is committed only on a successful submit (below),
+            // so a dropped/failed publish is still retried. Only ever suppresses literal duplicates.
+            var publishKey = FormatStateSnapshot(state) + "|qr=" + (state.QueueRevision ?? string.Empty);
             if (string.Equals(publishKey, _lastPublishKey, StringComparison.Ordinal))
             {
-                _logger?.LogTrace("PutState SKIP (identical to last published)");
+                _logger?.LogTrace("PutState SKIP (identical to last submitted)");
                 return;
             }
-            _lastPublishKey = publishKey;
 
             var now = (ulong)(_session?.Clock.NowMs ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
 
@@ -1071,6 +1071,9 @@ public sealed class PlaybackStateManager : IAsyncDisposable
             }
             else if (_statePublisher != null)
             {
+                // Commit the dedup key only now that the state actually reached the publisher —
+                // a dropped submit (above) leaves the key unchanged so the state is retried.
+                _lastPublishKey = publishKey;
                 Interlocked.Increment(ref _publishSubmittedCount);
                 _logger?.LogTrace("PutState queued: corrId={MessageId}, queueDepth={Depth}", request.MessageId, _statePublisher.PendingCount);
             }


### PR DESCRIPTION
**Fixes #6.**

The reporter (Surface Pro 11, ARM64, 0.1.0.1003) confirmed the earlier audio-engine fix worked — playback now connects. This PR fixes the **three pre-existing bugs that connecting playback then unblocked**: pressing Play **buffers then fails**, and navigating afterward goes **"응답없음" (Not Responding)**. All three were diagnosed from the diagnostics bundle the reporter exported via the in-app report flow (the feature working as intended).

These are **not regressions** — they live in playback / queue / UI-threading code that was simply never reached before, because the audio engine never connected on ARM64.

## Fixes

### A — Play silently fails (off-thread UI access)
`PlaybackPromptService.ResolvePlayActionAsync` read `Window.Content` / `XamlRoot` and showed a `ContentDialog` while on a **background thread** (`PlayContextAsync` is invoked via `Task.Run`), throwing `COMException 0x8001010E` (RPC_E_WRONG_THREAD) → the play task faulted **unobserved** → nothing played. Now marshals the UI interaction onto the UI thread (`MainWindow.DispatcherQueue` + `TaskCompletionSource`).

### B — Navigation hang/crash (bound-collection E_FAIL)
`PlaylistMutationCoordinator.ResetForNewPlaylist` raw-`Clear()`'d a bound `ObservableCollection` synchronously during navigation → `COMException` E_FAIL mid-layout. Switched to the resilient `ObservableCollectionExtensions.ReplaceWith`. **A follow-up audit found the same anti-pattern across the navigable pages** (including the two *other* resets in the same `Activate` flow) — all hardened in the second commit (`ReplaceWith` for live resets, `ClearWithoutNotify` for teardown).

### C — "Not responding" storm (per-track enqueue → PutState flood)
Bulk *Add to queue* / *Play next* enqueued tracks **one at a time**, and every orchestrator queue mutation publishes a Spotify **PutState** — so a 1777-track add fired **1777 PutStates** (each deep-cloning the whole queue), saturating the capacity-10 publisher and freezing the UI. Added **batch enqueue end-to-end** (`PlaybackQueue` → `PlaybackOrchestrator.*BatchAsync` → `IPlaybackService` / `ConnectCommandExecutor` → callers): N tracks → **one** mutation → **one** PutState. Plus a defensive dedup in `PlaybackStateManager.PublishLocalState` that drops a PutState identical to the previous one (keyed on the snapshot **including** `QueueRevision`, committed only on a successful submit).

## Auto-update (silent `.appinstaller` updates)

Also lands real silent auto-update so future fixes reach testers without a manual re-download. Windows App Installer downloads + stages new MSIX builds in the background; the app detects the staged update via `Package.CheckUpdateAvailabilityAsync` (no `packageManagement` capability) and surfaces a **"restart to apply"** nudge (toast + a Settings → About `InfoBar`); `AppInstance.Restart` applies it on relaunch.

- **Per-arch `.appinstaller`** (x64 **and** arm64). The previous template shipped an **x64-only `MainPackage`**, so ARM64 installs (the #6 reporter) had no package to update to — fixed.
- **Experimental** builds track a fixed **`experimental-latest`** rolling release (GitHub has no "latest pre-release" alias); **stable** tracks `/latest`. `release.yml` re-uploads the per-arch MSIX + appinstallers to the rolling release each build.
- App: `IUpdateService` / `UpdateService` gain `IsRestartUpdateReady`, `CheckPackageUpdateAsync`, `RestartToApplyUpdateAsync`; UI-affecting state is marshalled to the dispatcher (the post-launch check resumes off the UI thread). en-US + ko-KR strings included.

## Housekeeping
Removes the temporary `WAVEE_SIMULATE_AUDIO_FAILURE` / `SimulateStartupFailure` test hook used on the diagnostics branch to exercise the failure toast. The real `ProvisioningFailedExitCode` failure path is unchanged.

## Release
On merge to `experimental`, the **auto-published pre-release** (`v0.1.0-alpha.N`) delivers this fix — the #6 reporter should update to that build and retest play-from-list + navigation, and send a fresh diagnostics bundle if anything remains. (Auto-update itself only becomes verifiable once two such builds exist back-to-back.)

## Verification
- Play a playlist / home-card track → plays (no `RPC_E_WRONG_THREAD`).
- Navigate playlists / episodes / search / home rapidly (back/forward, deep links) → no `COMException` E_FAIL, no hang.
- Bulk *Add to queue* / *Play next* on a large multi-selection (+ drag a big selection) → one `Orchestrator: … batch → N` + one PutState, no `DROPPED PutState: publisher queue is full`, UI responsive; queue shows all N in order.
- Regression: single-track queue ops, shuffle / repeat / autoplay rollover, remote-device queue.
- Auto-update (needs two published builds): arm64 install of N → publish N+1 → background task stages it → "restart to apply" appears → **Restart now** lands on N+1; same for x64; experimental rolling tag advances alpha.N → alpha.N+1.

> Tested interactively; pending a clean local build before merge. AOT/trim analyzers run in every config.
