### PR TITLE
fix(audiohost): ship Release self-contained so audio runs without .NET 10 installed

### DIFF
--- a/src/Wavee.AudioHost/Wavee.AudioHost.csproj
+++ b/src/Wavee.AudioHost/Wavee.AudioHost.csproj
@@ -10,8 +10,14 @@
         <Product>Wavee</Product>
         <Description>Wavee Audio Runtime</Description>
 
-        <!-- Publish as self-contained for process isolation -->
+        <!-- Release / Release-Unpackaged ship to machines that may not have the
+             .NET 10 runtime installed, so bundle it (self-contained), mirroring
+             Wavee.UI.WinUI's SelfContained=true. A framework-dependent apphost
+             dies with host error 0x80008096 ("You must install or update .NET")
+             on any box without .NET 10. Debug / Debug-Unpackaged stay
+             framework-dependent for fast F5 / Hot Reload. -->
         <SelfContained>false</SelfContained>
+        <SelfContained Condition="$(Configuration.StartsWith('Release'))">true</SelfContained>
 
         <!-- Native AOT candidate (future) -->
         <IsAotCompatible>true</IsAotCompatible>


### PR DESCRIPTION
## Problem

A Premium user on **x64** (`0.1.0.1006`, channel `0.1.0-alpha.6`) reported the audio engine still won't load. The diagnostic bundle shows `Wavee.AudioHost.exe` exiting immediately at launch:

```
[AudioHost-err] You must install or update .NET to run this application.
[AudioHost-err] Architecture: x64
[AudioHost-err] Framework: 'Microsoft.NETCore.App', version '10.0.0' (x64)
[AudioHost-err] The following frameworks were found:
[AudioHost-err]   8.0.22 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
Audio host process exited (code=-2147450730, restarts=0/5)
```

`-2147450730` = `0x80008096` = the .NET host's **FrameworkMissingFailure**. After 5 restart attempts the UI gives up (`Pipe connection timed out after 60s` → `No fallback available`) and every playback command then fails with *"No active device and no local playback engine available."*

## Root cause

`src/Wavee.AudioHost/Wavee.AudioHost.csproj` had `<SelfContained>false</SelfContained>` (despite a comment claiming the opposite). In .NET 10 a `<RuntimeIdentifier>` does **not** imply self-contained, so the packaged `Wavee.AudioHost.exe` was **framework-dependent** — its apphost probes the target machine for `Microsoft.NETCore.App 10.0.0` and dies when only .NET 8 is present.

The WinUI process works because it already ships `SelfContained=true` for Release. AudioHost was simply never flipped to match (commit `66db35e` moved WinUI to self-contained JIT but not AudioHost) — hence the user's "**still**".

This affected **both** shipped packages: the release matrix builds an x64 and an arm64 MSIX, and the arm64 MSIX bundles the same x64 AudioHost.

## Fix

Make AudioHost self-contained for `Release` / `Release-Unpackaged` only:

```xml
<SelfContained>false</SelfContained>
<SelfContained Condition="$(Configuration.StartsWith('Release'))">true</SelfContained>
```

The .NET 10 runtime is now bundled next to the exe; the existing `CopyAudioHostToAppxLayout` / `IncludeAudioHostInMsixPayload` globs sweep it into the MSIX automatically under the isolated `Wavee.AudioHost\` subdir. Debug / Debug-Unpackaged stay framework-dependent for fast F5 / Hot Reload. Cost: ~+75 MB per MSIX.

## Verification

- [ ] `dotnet build src/Wavee.AudioHost/Wavee.AudioHost.csproj -c Release -p:Platform=x64` → `bin/x64/Release/net10.0/win-x64/` now contains the runtime (`coreclr.dll`, `System.Private.CoreLib.dll`, ~200 files) and `Wavee.AudioHost.runtimeconfig.json` has no shared-framework reference.
- [ ] Release MSIX `AppX\Wavee.AudioHost\` contains the .NET runtime DLLs (`[BuildAudioHost]` staged-file count jumps from ~30 to ~200+).
- [ ] **Definitive:** install on a machine with only .NET 8 → AudioHost starts, no `0x80008096`, audio plays.

Fixes the x64 + arm64 audio-engine startup failure for machines without the .NET 10 runtime.