### PR TITLE
perf(storage): drop SQLite shared-cache + batch rootlist persist (startup write-lock storm)

### DIFF
--- a/src/Wavee/Core/Http/ExtendedMetadataClient.cs
+++ b/src/Wavee/Core/Http/ExtendedMetadataClient.cs
@@ -152,20 +152,34 @@ public sealed class ExtendedMetadataClient : IExtendedMetadataClient
         if (data == null)
             return null;
 
+        Track track;
         try
         {
-            var track = Track.Parser.ParseFrom(data);
-
-            // Store queryable properties
-            await StoreTrackPropertiesAsync(trackUri, track, cancellationToken);
-
-            return track;
+            track = Track.Parser.ParseFrom(data);
         }
         catch (Exception ex)
         {
             _logger?.LogWarning(ex, "Failed to parse Track from TRACK_V4 extension data");
             return null;
         }
+
+        // Caching queryable properties is best-effort. A cancelled or write-lock-contended
+        // metadata-DB write must NOT masquerade as a parse failure, and the parsed track is
+        // still valid to return even when the cache write didn't land.
+        try
+        {
+            await StoreTrackPropertiesAsync(trackUri, track, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger?.LogDebug("Track-properties cache write cancelled for {Uri}", trackUri);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to cache track properties for {Uri}", trackUri);
+        }
+
+        return track;
     }
 
     /// <summary>

--- a/src/Wavee/Core/Playlists/PlaylistCacheService.cs
+++ b/src/Wavee/Core/Playlists/PlaylistCacheService.cs
@@ -689,13 +689,24 @@ public sealed class PlaylistCacheService : IPlaylistCacheService, IDisposable
             },
             ct);
 
+        // Read + merge each summary first (reads take no write lock), then write them
+        // all under a SINGLE write-batch transaction. Previously this loop took the
+        // write lock once per playlist (103 acquisitions on a typical rootlist), which
+        // flooded the lock and starved foreground metadata writes during startup sync.
+        var mergedEntries = new List<PlaylistCacheEntry>(snapshot.Items.Count);
         foreach (var playlistEntry in snapshot.Items.OfType<RootlistPlaylist>())
         {
             snapshot.Decorations.TryGetValue(playlistEntry.Uri, out var decoration);
             var existing = await _database.GetPlaylistCacheEntryAsync(playlistEntry.Uri, touchAccess: false, ct);
-            var merged = MergeSummaryEntry(playlistEntry.Uri, decoration, existing, snapshot.FetchedAt);
-            await _database.UpsertPlaylistCacheEntryAsync(merged, ct);
+            mergedEntries.Add(MergeSummaryEntry(playlistEntry.Uri, decoration, existing, snapshot.FetchedAt));
         }
+
+        if (mergedEntries.Count == 0)
+            return;
+
+        await using var batch = await _database.BeginWriteBatchAsync(ct);
+        foreach (var entry in mergedEntries)
+            await batch.UpsertPlaylistCacheEntryAsync(entry, ct);
     }
 
     private async Task<CachedPlaylist> FetchPlaylistFromNetworkAsync(

--- a/src/Wavee/Core/Storage/Abstractions/IWriteBatch.cs
+++ b/src/Wavee/Core/Storage/Abstractions/IWriteBatch.cs
@@ -1,3 +1,4 @@
+using Wavee.Core.Storage.Entities;
 using Wavee.Protocol.ExtendedMetadata;
 
 namespace Wavee.Core.Storage.Abstractions;
@@ -61,5 +62,14 @@ public interface IWriteBatch : IAsyncDisposable
         string? streamUrl = null,
         long? expiresAt = null,
         long? addedAt = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Upserts a playlist cache entry row in this batch's transaction. Mirrors the
+    /// standalone <c>IMetadataDatabase.UpsertPlaylistCacheEntryAsync</c>, letting many
+    /// rows (e.g. a whole rootlist) be persisted under one transaction.
+    /// </summary>
+    Task UpsertPlaylistCacheEntryAsync(
+        PlaylistCacheEntry playlist,
         CancellationToken cancellationToken = default);
 }

--- a/src/Wavee/Core/Storage/MetadataDatabase.cs
+++ b/src/Wavee/Core/Storage/MetadataDatabase.cs
@@ -114,12 +114,18 @@ public sealed class MetadataDatabase : IMetadataDatabase
             Directory.CreateDirectory(directory);
         }
 
-        // Build connection string with WAL mode for better concurrency
+        // Private cache (the default) + WAL is SQLite's recommended high-concurrency
+        // setup: readers get a committed snapshot and never block the single writer,
+        // and the writer never blocks readers. Shared cache (previously set here)
+        // instead routes every connection through process-wide table-level locks, which
+        // — under the startup playlist-prefetch burst (4 concurrent workers + the
+        // rootlist persist) — blocked even single-row writes for ~150ms each and
+        // produced a write-lock-wait storm. WAL already gives cross-connection
+        // visibility for this file-backed DB, so shared cache bought nothing.
         var builder = new SqliteConnectionStringBuilder
         {
             DataSource = databasePath,
-            Mode = SqliteOpenMode.ReadWriteCreate,
-            Cache = SqliteCacheMode.Shared
+            Mode = SqliteOpenMode.ReadWriteCreate
         };
         _connectionString = builder.ConnectionString;
 
@@ -3455,8 +3461,23 @@ public sealed class MetadataDatabase : IMetadataDatabase
         using var __lease = await AcquireWriteLockAsync(nameof(UpsertPlaylistCacheEntryAsync), 1, cancellationToken);
         using var connection = CreateConnection();
         await connection.OpenAsync(cancellationToken);
+        await ExecuteUpsertPlaylistCacheEntryAsync(connection, null, playlist, cancellationToken);
+    }
 
+    // Core upsert shared by the standalone method above (own connection, autocommit)
+    // and the write-batch path (IWriteBatch.UpsertPlaylistCacheEntryAsync — shared
+    // connection + transaction), mirroring ExecuteUpsertEntityAsync. Lets the rootlist
+    // persist write all playlist rows under ONE transaction instead of one lock
+    // acquisition per row.
+    private async Task ExecuteUpsertPlaylistCacheEntryAsync(
+        SqliteConnection connection,
+        SqliteTransaction? transaction,
+        PlaylistCacheEntry playlist,
+        CancellationToken cancellationToken)
+    {
         using var cmd = connection.CreateCommand();
+        if (transaction != null)
+            cmd.Transaction = transaction;
         cmd.CommandText = """
             INSERT INTO spotify_playlists (
                 id, name, owner_id, owner_name, description, image_url, header_image_url, track_count,
@@ -4649,6 +4670,15 @@ public sealed class MetadataDatabase : IMetadataDatabase
                 trackCount, followerCount, publisher, episodeCount, description,
                 filePath, streamUrl, expiresAt, addedAt,
                 useLocalizedTable, now, cancellationToken);
+        }
+
+        public Task UpsertPlaylistCacheEntryAsync(
+            PlaylistCacheEntry playlist,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            ArgumentNullException.ThrowIfNull(playlist);
+            return _owner.ExecuteUpsertPlaylistCacheEntryAsync(Connection, Transaction, playlist, cancellationToken);
         }
 
         private void ThrowIfDisposed()


### PR DESCRIPTION
## Problem

The diagnostic bundle behind the audio report also showed an ~8 s startup write-lock storm right after library sync, while the playlist prefetch warms 103 playlists:

```
[WRN] MetadataDatabase write lock wait: waiter=UpsertPlaylistCacheEntryAsync items=1 owner=UpsertPlaylistCacheEntryAsync(1) heldMs=~155
[WRN] MetadataDatabase write lock acquired after slow wait: ... waitMs=416-577   (×dozens)
```

…and a foreground track-metadata write got starved/cancelled and **mislabeled**:

```
[WRN] Failed to parse Track from TRACK_V4 extension data
System.Threading.Tasks.TaskCanceledException: ... at MetadataDatabase.AcquireWriteLockAsync
       at ExtendedMetadataClient.GetTrackAsync
```

## Root cause

`PersistRootlistAsync` looped one `UpsertPlaylistCacheEntryAsync` **per playlist** (103 separate write-lock acquisitions) while 4 concurrent prefetch workers also wrote. The connection string used **`Cache=SqliteCacheMode.Shared`**, whose process-wide table-level locks serialized even single-row writes against the concurrent readers/writers, holding the lock ~150 ms each.

Evidence pinned the cost to shared-cache contention, **not** connection-open or fsync: `BeginWriteBatchAsync` already instruments connection-open and only logs `openConn>=50ms` — that line never fired (pooling is on) — and `commit=5ms` showed fsync was fast.

## Fix (surgical, evidence-backed)

- **Drop `Cache=Shared`** → private cache. With WAL + pooling, readers get a committed snapshot and never block the single writer, and the writer never blocks readers (SQLite's recommended high-concurrency setup). Nothing depended on shared-cache semantics (no `read_uncommitted`, no `:memory:`, file-backed DB).
- **Batch the rootlist persist**: read+merge all summaries first (no lock), then write them under **one** `BeginWriteBatchAsync` transaction — 103 lock acquisitions collapse to 1. Adds `IWriteBatch.UpsertPlaylistCacheEntryAsync` + a shared `ExecuteUpsertPlaylistCacheEntryAsync` core (mirrors the existing `ExecuteUpsertEntityAsync` split).
- **Fix the mislabeled log**: `GetTrackAsync` now parses in its own `try`, then does the properties-cache write as best-effort — a cancelled/contended DB write is logged accurately (debug) instead of as a bogus parse failure, and the parsed track is still returned.

### Scope note (re: the approved plan)

The approved plan's connection-model option was "drop `Cache=Shared` **and/or** reuse one long-lived writer connection across ~40 write sites." During implementation the evidence above proved per-connection **open is not the cost** (pooling; the `openConn` instrument never fired), so reusing a single writer connection would be ~42 fragile edits to the core storage class for **no** measurable benefit. I therefore took the `Cache=Shared` branch — the change that addresses the confirmed cause — and left the per-call (now private-cache, pooled) connections in place. Happy to add the writer-connection refactor as a follow-up if the verification below still shows write starvation.

## Verification (build + run; not run here)

- Fresh startup with a large library: the `write lock wait … acquired after slow wait` storm is gone/minimal; `Playlist prefetch: complete` arrives sooner; no `TaskCanceledException … at AcquireWriteLockAsync`; the parse-vs-cancel log reads accurately.
- The existing `ReleaseWriteLock` held-time WARN (≥250 ms) and `BeginWriteBatch` timing logs now isolate SQL-exec vs fsync (open already proven cheap) — they should stay quiet.
- Library/playlist data still loads correctly (reads unaffected by the cache-mode change); no SQLITE_BUSY/locked under concurrent prefetch.
- `dotnet test test/Wavee.Tests/...` storage suite still green.