### PR TITLE
fix(artist): kill the artist→artist navigation flicker (stale hero scrolls up then shimmers)

### DIFF
--- a/src/Wavee.UI.WinUI/ViewModels/ArtistViewModel.cs
+++ b/src/Wavee.UI.WinUI/ViewModels/ArtistViewModel.cs
@@ -343,6 +343,29 @@ public sealed partial class ArtistViewModel : ObservableObject, ITabBarItemConte
 
     // ── Initialization ──────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Cheap, synchronous front-half of an artist swap, run on the navigation's
+    /// synchronous path (before ScrollTo / first paint) so a reused page never
+    /// shows the previous artist at the new scroll position. Nulls the header
+    /// (the hero's projected scalars blank via [NotifyPropertyChangedFor]),
+    /// clears the section collections, and arms the loading state. The expensive
+    /// store-subscribe / enrich / Bindings.Update stays deferred — the full
+    /// <see cref="Initialize"/> runs on the deferred tick and harmlessly re-does
+    /// the (now no-op) clear before subscribing. No-op when the artist is unchanged.
+    /// </summary>
+    public void BeginArtistSwap(string artistId)
+    {
+        if (string.IsNullOrEmpty(artistId)
+            || string.Equals(ArtistId, artistId, StringComparison.Ordinal))
+            return;
+
+        Interlocked.Increment(ref _loadGeneration);
+        ResetForNewArtist();
+        _appliedOverviewFor = null;
+        _appliedOverview = null;
+        IsLoading = true;
+    }
+
     public void Initialize(string artistId)
     {
         AttachLongLivedServices();

--- a/src/Wavee.UI.WinUI/Views/ArtistPage.xaml.cs
+++ b/src/Wavee.UI.WinUI/Views/ArtistPage.xaml.cs
@@ -227,6 +227,19 @@ public sealed partial class ArtistPage : UserControl, ITabBarItemContent, INavig
             _showingContent = false;
             _crossfadeScheduled = false;
             ShimmerGate.Reset(() => ShimmerContainer, () => BodyContent);
+
+            // Clear the OUTGOING artist + arm loading SYNCHRONOUSLY, before the
+            // Task.Yield + ScrollTo(0) below. The hero (artist photo + name) sits
+            // outside the shimmer gate and is force-shown by ForceHeroVisualsVisible,
+            // so without this it stays bound to the previous artist while the page
+            // scrolls to the top — then only blanks when the DEFERRED
+            // ViewModel.Initialize tick runs. That lag is the "old artist content →
+            // scrolls up → shimmer" flicker. BeginArtistSwap nulls Header.Artist,
+            // whose [NotifyPropertyChangedFor] fan-out blanks the hero's OneWay
+            // x:Binds this frame; the expensive subscribe / enrich / Bindings.Update
+            // still runs deferred in InitializeArtistDeferred.
+            if (!string.IsNullOrEmpty(uri))
+                ViewModel.BeginArtistSwap(uri);
         }
 
         // Yield once between the shimmer flip and the heavy VM-init /


### PR DESCRIPTION
## Problem

Navigating from one artist to another shows an ugly flicker: the **previous** artist's content is briefly visible, the page **scrolls up**, and only **then** does it drop into the shimmer/loading state before the new artist appears.

## Root cause

`ArtistPage` opts into instance reuse (`ReuseForParameterNavigation => true`), so artist→artist reuses the same page + ViewModel. In `EnterArtistAsync`:

- The **body** is hidden synchronously — `ShimmerGate.Reset(...)` sets `BodyContent.Opacity = 0`.
- But the **hero** (artist photo + name) lives *outside* the shimmer gate and is force-shown by `ForceHeroVisualsVisible()`.
- The actual artist **clear** — `ViewModel.Initialize` → `ResetForNewArtist()`, which nulls `Header.Artist` and blanks the hero — is deliberately **deferred** to a `DispatcherQueuePriority.Low` tick (perf: it ran ~270 ms inline and blocked the entrance animation).
- Meanwhile `PageScrollView.ScrollTo(0,0)` runs **synchronously**, *before* that deferred clear.

Net effect: the previous artist's hero gets scrolled to the top and lingers for a frame or more until the Low-priority tick finally clears it → "old artist → scrolls up → shimmer."

## Fix

Split the swap: a new cheap, synchronous **`ArtistViewModel.BeginArtistSwap(uri)`** (bump load generation, `ResetForNewArtist()`, `IsLoading = true`) is called on the **synchronous** nav path *before* the `Task.Yield`/`ScrollTo`. Nulling `Header.Artist` fires its `[NotifyPropertyChangedFor]` fan-out (`ArtistName`/`ArtistImageUrl`/`HeaderHeroColorHex`/…), so the hero's OneWay `x:Bind`s blank **this frame** — no stale artist at the new scroll position.

The expensive work (store subscribe, top-track enrich, discography query, palette, video prewarm, bio, `Bindings.Update`) **stays deferred** in `InitializeArtistDeferred`; the full `Initialize` re-runs the now-no-op clear before subscribing. Scoped to non-Back/Forward navigations so Back/Forward stay cache-hits with content preserved.

Files: `ArtistViewModel.cs` (+`BeginArtistSwap`), `ArtistPage.xaml.cs` (call it in `EnterArtistAsync`). +36 lines, no deletions.

## Verification (build + run; not run here)

Navigate artist → artist (especially after scrolling down on the first one):
- The previous artist's hero no longer flashes / scrolls up — the page goes straight to the shimmer/loading state, then the new artist fades in.
- Back/Forward between artists still restores instantly (no shimmer flash, scroll preserved) — unchanged.
- Re-clicking the *same* artist is a no-op swap (guarded by the `ArtistId` equality check).