### PR TITLE
feat(update): self-stage MSIX updates so they apply on restart

### DIFF
--- a/signing/Wavee.appinstaller.template
+++ b/signing/Wavee.appinstaller.template
@@ -26,7 +26,7 @@
        next restart. The app surfaces a "restart to update" nudge via
        Package.CheckUpdateAvailabilityAsync (no package-management capability needed). -->
   <UpdateSettings>
-    <OnLaunch HoursBetweenUpdateChecks="8" ShowPrompt="false" />
+    <OnLaunch HoursBetweenUpdateChecks="4" ShowPrompt="false" />
     <AutomaticBackgroundTask />
   </UpdateSettings>
 

--- a/src/Wavee.UI.WinUI/Controls/Settings/AboutSettingsSection.xaml
+++ b/src/Wavee.UI.WinUI/Controls/Settings/AboutSettingsSection.xaml
@@ -91,6 +91,18 @@
                     </controls:SettingsExpander.Items>
                 </controls:SettingsExpander>
 
+                <controls:SettingsCard x:Uid="Controls_Settings_AboutSettingsSection__SettingsCard_AutoUpdate"
+                                       Header="Automatic updates"
+                                       Description="Download and install updates automatically; they apply when you restart Wavee"
+                                       Tag="updates"
+                                       Margin="0,12,0,0"
+                                       Visibility="{x:Bind ViewModel.IsAutoUpdateToggleVisible, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                    <controls:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xE777;"/>
+                    </controls:SettingsCard.HeaderIcon>
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.AutoUpdateEnabled, Mode=TwoWay}"/>
+                </controls:SettingsCard>
+
                 <controls:SettingsCard x:Uid="Controls_Settings_AboutSettingsSection__SettingsCard_10" Header="What's new"
                                        Description="See the latest features and improvements"
                                        IsClickEnabled="True"

--- a/src/Wavee.UI.WinUI/Data/Models/AppSettings.cs
+++ b/src/Wavee.UI.WinUI/Data/Models/AppSettings.cs
@@ -232,6 +232,13 @@ public sealed class AppSettings
     /// </summary>
     public string? LastSeenChangelogVersion { get; set; }
 
+    /// <summary>
+    /// When true, an available MSIX update is downloaded + staged automatically (via
+    /// PackageManager) so it applies on the next restart. Sideloaded installs only.
+    /// Defaults on; a missing key in older settings.json leaves existing users opted in.
+    /// </summary>
+    public bool AutoUpdate { get; set; } = true;
+
     // ── Library (per-tab sort + view preferences) ──
 
     /// <summary>

--- a/src/Wavee.UI.WinUI/Services/IUpdateService.cs
+++ b/src/Wavee.UI.WinUI/Services/IUpdateService.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Wavee.UI.WinUI.Services;
 
-public enum UpdateStatus { Idle, Checking, UpdateAvailable, UpToDate, Error }
+public enum UpdateStatus { Idle, Checking, UpdateAvailable, Downloading, UpToDate, Error }
 public enum DistributionMode { Store, Sideloaded, Unpackaged }
 
 /// <summary>
@@ -24,13 +24,34 @@ public interface IUpdateService : INotifyPropertyChanged
     bool IsUpdateAvailable { get; }
 
     /// <summary>
-    /// True once Windows App Installer has a newer package available/staged for this
-    /// <c>.appinstaller</c> install — the app should nudge the user to restart to apply it.
-    /// Always false for Store / Unpackaged installs.
+    /// True once a newer package has been genuinely DOWNLOADED + STAGED for this
+    /// <c>.appinstaller</c> install, so a restart will apply it. Always false for
+    /// Store / Unpackaged installs.
     /// </summary>
     bool IsRestartUpdateReady { get; }
 
+    /// <summary>
+    /// When true, an available update is downloaded + staged automatically so a restart
+    /// applies it. Persisted as <c>AppSettings.AutoUpdate</c>. Sideloaded installs only.
+    /// </summary>
+    bool IsAutoUpdateEnabled { get; set; }
+
+    /// <summary>True while an MSIX update is being downloaded + staged.</summary>
+    bool IsDownloadingUpdate { get; }
+
+    /// <summary>Download/stage progress in [0, 1] while <see cref="IsDownloadingUpdate"/> is true.</summary>
+    double DownloadProgress { get; }
+
     Task CheckForUpdateAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Actively downloads + stages the newer MSIX from this install's <c>.appinstaller</c> via
+    /// <c>PackageManager.AddPackageByAppInstallerFileAsync</c> (instead of waiting on Windows App
+    /// Installer's own schedule). On success the staged package applies on the next restart and
+    /// <see cref="IsRestartUpdateReady"/> is set. No-op (false) for Store / Unpackaged installs.
+    /// Self-update of the same package family needs no package-management capability.
+    /// </summary>
+    Task<bool> DownloadAndStageUpdateAsync(CancellationToken ct = default);
 
     /// <summary>
     /// Checks whether the installed MSIX has a newer version staged via its <c>.appinstaller</c>

--- a/src/Wavee.UI.WinUI/Services/UpdateService.cs
+++ b/src/Wavee.UI.WinUI/Services/UpdateService.cs
@@ -37,6 +37,19 @@ public sealed partial class UpdateService : IUpdateService
     private DateTimeOffset? _lastChecked;
     private bool _isUpdateAvailable;
     private bool _isRestartUpdateReady;
+    private bool _isAutoUpdateEnabled;
+    private bool _isDownloadingUpdate;
+    private double _downloadProgress;
+
+    // Serializes staging so the startup check and the Settings OnAboutLoaded re-check can't both
+    // kick AddPackageByAppInstallerFileAsync for the same update.
+    private readonly SemaphoreSlim _stageLock = new(1, 1);
+
+    // Per-arch fallback when GetAppInstallerInfo() can't supply the channel URI (e.g. the package
+    // was installed by an older client). Mirrors the experimental asset names emitted by
+    // signing/Generate-AppInstaller.ps1 — keep in sync with signing/Wavee.appinstaller.template.
+    private const string ExperimentalAppInstallerUrlBase =
+        "https://github.com/christosk92/WaveeMusic/releases/download/experimental-latest/Wavee.Experimental.";
 
     public UpdateService(
         IHttpClientFactory httpClientFactory,
@@ -54,6 +67,7 @@ public sealed partial class UpdateService : IUpdateService
 
         // Restore last checked time
         _lastChecked = _settingsService.Settings.LastUpdateCheck;
+        _isAutoUpdateEnabled = _settingsService.Settings.AutoUpdate;
 
         // Fire-and-forget initial check after a short delay to let the app settle. The work
         // lives in an async method (not Task.Delay(...).ContinueWith(async _ => ...)) so the
@@ -170,6 +184,28 @@ public sealed partial class UpdateService : IUpdateService
     {
         get => _isRestartUpdateReady;
         private set => SetField(ref _isRestartUpdateReady, value);
+    }
+
+    public bool IsAutoUpdateEnabled
+    {
+        get => _isAutoUpdateEnabled;
+        set
+        {
+            if (SetField(ref _isAutoUpdateEnabled, value))
+                _settingsService.Update(s => s.AutoUpdate = value);
+        }
+    }
+
+    public bool IsDownloadingUpdate
+    {
+        get => _isDownloadingUpdate;
+        private set => SetField(ref _isDownloadingUpdate, value);
+    }
+
+    public double DownloadProgress
+    {
+        get => _downloadProgress;
+        private set => SetField(ref _downloadProgress, value);
     }
 
     public async Task CheckForUpdateAsync(CancellationToken ct = default)
@@ -319,16 +355,25 @@ public sealed partial class UpdateService : IUpdateService
         }
 
         if (IsRestartUpdateReady)
-            return; // already nudged this session
+            return; // already staged + nudged this session
 
-        _logger?.LogInformation(
-            "MSIX update staged via .appinstaller; prompting restart (availability={Availability})",
-            availability);
-
-        // Safe from the threadpool continuation: ShowRestartReadyNudge sets IsRestartUpdateReady
-        // (its PropertyChanged is marshalled to the UI thread by SetField) and posts a toast
-        // (NotificationService.Show marshals itself).
-        ShowRestartReadyNudge();
+        if (IsAutoUpdateEnabled)
+        {
+            // Actively download + stage now instead of waiting on Windows App Installer's own
+            // schedule. On success this sets IsRestartUpdateReady and posts the restart nudge.
+            _logger?.LogInformation(
+                "Newer MSIX available (availability={Availability}); auto-staging via PackageManager",
+                availability);
+            await DownloadAndStageUpdateAsync(ct).ConfigureAwait(false);
+        }
+        else
+        {
+            // Auto-update off: don't claim it's already downloaded — offer download + restart.
+            _logger?.LogInformation(
+                "Newer MSIX available (availability={Availability}); auto-update off, offering download",
+                availability);
+            ShowDownloadAvailableNudge();
+        }
     }
 
     private void ShowRestartReadyNudge()
@@ -344,13 +389,153 @@ public sealed partial class UpdateService : IUpdateService
         });
     }
 
-    public Task RestartToApplyUpdateAsync()
+    private void ShowDownloadAvailableNudge()
+    {
+        _notificationService?.Show(new NotificationInfo
+        {
+            Message = AppLocalization.Format("Update_AvailableDownloadMessage", LatestVersion),
+            Severity = NotificationSeverity.Informational,
+            AutoDismissAfter = TimeSpan.FromSeconds(10),
+            ActionLabel = AppLocalization.GetString("Update_DownloadAndRestart"),
+            Action = async () =>
+            {
+                if (await DownloadAndStageUpdateAsync().ConfigureAwait(false))
+                    await RestartToApplyUpdateAsync().ConfigureAwait(false);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The <c>.appinstaller</c> URI this package updates from — the OS-recorded value
+    /// (<c>Package.GetAppInstallerInfo</c>), falling back to the per-arch experimental constant.
+    /// Null when neither resolves (e.g. not installed from an .appinstaller).
+    /// </summary>
+    private Uri? ResolveAppInstallerUri()
     {
         try
         {
-            // Full process restart so Windows applies the staged MSIX on relaunch. This is a
-            // hard process replacement (distinct from UiRestartCoordinator's UI-only restart) —
-            // on success it terminates the current process and never returns.
+            if (Package.Current.GetAppInstallerInfo()?.Uri is { } uri)
+                return uri;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "GetAppInstallerInfo failed; falling back to per-arch constant");
+        }
+
+        var arch = Package.Current.Id.Architecture switch
+        {
+            Windows.System.ProcessorArchitecture.X64 => "x64",
+            Windows.System.ProcessorArchitecture.Arm64 => "arm64",
+            _ => null
+        };
+        if (arch is null)
+        {
+            _logger?.LogWarning("No .appinstaller URI and unsupported arch {Arch}", Package.Current.Id.Architecture);
+            return null;
+        }
+        return new Uri($"{ExperimentalAppInstallerUrlBase}{arch}.appinstaller");
+    }
+
+    public async Task<bool> DownloadAndStageUpdateAsync(CancellationToken ct = default)
+    {
+        if (Distribution != DistributionMode.Sideloaded)
+            return false;
+        if (IsRestartUpdateReady)
+            return true; // already staged this session
+        if (!await _stageLock.WaitAsync(0, ct).ConfigureAwait(false))
+            return false; // a stage is already in flight
+
+        try
+        {
+            var uri = ResolveAppInstallerUri();
+            if (uri is null)
+                return false;
+
+            Status = UpdateStatus.Downloading;
+            IsDownloadingUpdate = true;
+            DownloadProgress = 0;
+            ErrorMessage = null;
+
+            var packageManager = new Windows.Management.Deployment.PackageManager();
+            // None: registration of the newer package DEFERS while this one is in use and commits
+            // on the next launch (zero processes); we apply on demand via the AudioHost-kill
+            // restart. Self-update of the same package family needs no packageManagement
+            // capability (runFullTrust suffices) — Microsoft "non-store-developer-updates".
+            var operation = packageManager.AddPackageByAppInstallerFileAsync(
+                uri,
+                Windows.Management.Deployment.AddPackageByAppInstallerOptions.None,
+                null);
+            operation.Progress = (_, p) => DownloadProgress = p.percentage / 100.0;
+
+            var result = await operation.AsTask(ct).ConfigureAwait(false);
+
+            if (result.ExtendedErrorCode is { HResult: not 0 } err)
+            {
+                _logger?.LogWarning("Update stage failed: hr=0x{Hr:X8} {ErrorText}", err.HResult, result.ErrorText);
+                Status = UpdateStatus.Error;
+                ErrorMessage = string.IsNullOrWhiteSpace(result.ErrorText)
+                    ? AppLocalization.GetString("Update_DownloadFailed")
+                    : result.ErrorText;
+                return false;
+            }
+
+            _logger?.LogInformation("MSIX update staged via PackageManager; will apply on next restart");
+            Status = UpdateStatus.UpdateAvailable;
+            IsRestartUpdateReady = true;
+            ShowRestartReadyNudge();
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Access-denied (capability), network, signature, downgrade — degrade to the passive
+            // App-Installer path; the user is no worse off than before.
+            _logger?.LogWarning(ex, "DownloadAndStageUpdateAsync failed; falling back to passive update path");
+            Status = UpdateStatus.Error;
+            ErrorMessage = ex.Message;
+            return false;
+        }
+        finally
+        {
+            IsDownloadingUpdate = false;
+            DownloadProgress = 0;
+            _stageLock.Release();
+        }
+    }
+
+    public async Task RestartToApplyUpdateAsync()
+    {
+        try
+        {
+            // A staged MSIX update is only committed when the package has NO
+            // running processes left. The out-of-process audio host
+            // (Wavee.AudioHost — same package identity) is deliberately kept
+            // alive across UI restarts for the UI-only handoff: its job object
+            // uses LimitFlags=0, so it survives the UI process exiting. For an
+            // UPDATE restart we want the opposite — a full cold restart of the
+            // whole package — so tear the audio host down first. Without this,
+            // AppInstance.Restart relaunches the still-registered OLD version
+            // (the package never reached zero processes) and the "restart to
+            // update" nudge just reappears, which is the bug this fixes.
+            var audio = Wavee.UI.WinUI.Helpers.Application.AppLifecycleHelper.AudioProcessManager;
+            if (audio is not null)
+            {
+                try
+                {
+                    await audio.StopAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, "Failed to stop audio host before update restart; continuing");
+                }
+            }
+
+            // Hard process replacement; on success it terminates the current
+            // process and never returns. With the audio host gone the package is
+            // fully unloaded, so Windows commits the staged MSIX on relaunch.
             var reason = Microsoft.Windows.AppLifecycle.AppInstance.Restart(string.Empty);
             _logger?.LogWarning("AppInstance.Restart returned without restarting ({Reason})", reason);
         }
@@ -358,7 +543,6 @@ public sealed partial class UpdateService : IUpdateService
         {
             _logger?.LogWarning(ex, "Restart to apply update failed");
         }
-        return Task.CompletedTask;
     }
 
     private void ReportNoUpdate(string reason)

--- a/src/Wavee.UI.WinUI/Strings/en-US/Resources.resw
+++ b/src/Wavee.UI.WinUI/Strings/en-US/Resources.resw
@@ -285,6 +285,12 @@
   <data name="Controls_Settings_AboutSettingsSection__SettingsCard_10.Header" xml:space="preserve">
     <value>Release notes</value>
   </data>
+  <data name="Controls_Settings_AboutSettingsSection__SettingsCard_AutoUpdate.Header" xml:space="preserve">
+    <value>Automatic updates</value>
+  </data>
+  <data name="Controls_Settings_AboutSettingsSection__SettingsCard_AutoUpdate.Description" xml:space="preserve">
+    <value>Download and install updates automatically; they apply when you restart Wavee</value>
+  </data>
   <data name="Controls_Settings_AboutSettingsSection__SettingsCard_12.Description" xml:space="preserve">
     <value>Report bugs, request features, or share your thoughts</value>
   </data>
@@ -1908,6 +1914,15 @@ Supports Markdown: **bold**, _italic_, `code`, - lists</value>
   </data>
   <data name="Update_RestartNow" xml:space="preserve">
     <value>Restart now</value>
+  </data>
+  <data name="Update_AvailableDownloadMessage" xml:space="preserve">
+    <value>Wavee v{0} is available — download and restart to update</value>
+  </data>
+  <data name="Update_DownloadAndRestart" xml:space="preserve">
+    <value>Download &amp; restart</value>
+  </data>
+  <data name="Update_DownloadFailed" xml:space="preserve">
+    <value>Couldn't download the update — it'll retry later.</value>
   </data>
   <data name="Connect_RequestingPairingCode" xml:space="preserve">
     <value>Requesting pairing code...</value>

--- a/src/Wavee.UI.WinUI/ViewModels/SettingsViewModel.cs
+++ b/src/Wavee.UI.WinUI/ViewModels/SettingsViewModel.cs
@@ -105,6 +105,10 @@ public sealed partial class SettingsViewModel : ObservableObject, IDisposable
 
     public bool HasUpdateError => _updateService?.Status == UpdateStatus.Error;
 
+    // The auto-update toggle only makes sense for sideloaded (.appinstaller) installs — Store
+    // updates itself; unpackaged dev builds have no package to stage.
+    public bool IsAutoUpdateToggleVisible => _updateService?.Distribution == DistributionMode.Sideloaded;
+
     public string DistributionModeDisplay => _updateService?.Distribution switch
     {
         DistributionMode.Store => AppLocalization.GetString("DistributionMode_Store"),
@@ -200,6 +204,7 @@ public sealed partial class SettingsViewModel : ObservableObject, IDisposable
         MinimizeToTrayOnClose = s.MinimizeToTrayOnClose;
         ShowDockedPlayerWithFloatingPlayer = s.ShowDockedPlayerWithFloatingPlayer;
         ShowLocalFilesOnHome = s.ShowLocalFilesOnHome;
+        AutoUpdateEnabled = s.AutoUpdate;
 
         // Initialize lyrics sources from persisted prefs or defaults
         InitializeLyricsSources(s);
@@ -633,6 +638,19 @@ public sealed partial class SettingsViewModel : ObservableObject, IDisposable
         // next end-of-context evaluation with no further plumbing.
         _settingsService.Update(s => s.AutoplayEnabled = value);
         WeakReferenceMessenger.Default.Send(new AutoplayEnabledChangedMessage(value));
+    }
+
+    [ObservableProperty]
+    public partial bool AutoUpdateEnabled { get; set; }
+
+    partial void OnAutoUpdateEnabledChanged(bool value)
+    {
+        // The update service owns persistence (writes AppSettings.AutoUpdate); fall back to a
+        // direct settings write if the service wasn't injected (tests / minimal hosts).
+        if (_updateService is not null)
+            _updateService.IsAutoUpdateEnabled = value;
+        else
+            _settingsService.Update(s => s.AutoUpdate = value);
     }
 
     [ObservableProperty]


### PR DESCRIPTION
@
## What

The sideloaded updater only **detected** updates. `Package.CheckUpdateAvailabilityAsync() == Available` means *"a newer version exists in the channel"*, **not** *"downloaded"* — yet the app showed *"A new version has been downloaded. Restart to apply it."* So restarting never advanced the version until Windows App Installer happened to fetch it on its own ~8h schedule.

This makes the app **actively download + stage** the new MSIX itself.

## How

- `DownloadAndStageUpdateAsync` → `PackageManager.AddPackageByAppInstallerFileAsync(uri, AddPackageByAppInstallerOptions.None, null)`. `None` = deferred registration: the staged package applies on the next restart (zero processes). Self-update of the same package family needs **no `packageManagement` capability** (`runFullTrust` suffices), so the Phi Silica LAF is untouched.
- Channel URI from `Package.GetAppInstallerInfo()?.Uri`, with a per-arch `experimental-latest` constant fallback.
- `IsRestartUpdateReady` + the "restart to apply" nudge now fire **only after a real stage**, so the message is finally truthful.
- `RestartToApplyUpdateAsync` tears down the out-of-process audio host (`AudioProcessManager.StopAsync`) first, so the package reaches zero processes and Windows commits the staged build — the apply step that was silently failing because `Wavee.AudioHost` kept the package alive.
- New `AutoUpdate` setting (default on) + a sideload-only Settings toggle.
- Lower the `.appinstaller` `OnLaunch` check `8h → 4h` as a passive safety net.

## Notes

- **Chicken-and-egg:** the active path only works *from* a build that ships it. The currently-installed version still needs one manual apply (`Add-AppxPackage -AppInstallerFile …arm64.appinstaller`) to land on the first fix-containing build; from there itʼs automatic.
- No other `IUpdateService` implementers; no exhaustive `switch` on `UpdateStatus`, so the new `Downloading` enum value is safe under warnings-as-errors. All new APIs are plain WinRT projections (trim/AOT-clean).
- Out of scope: in-app changelog markdown rendering.
@