### PR TITLE
[codex] add MSIX installer badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ A modern, open-source Spotify desktop client for Windows — built with .NET 10 
 ![WinUI](https://img.shields.io/badge/WinUI-3-0078D4?logo=windows)
 ![License](https://img.shields.io/badge/License-MIT-green)
 
+<p>
+  <a href="https://github.com/christosk92/WaveeMusic/releases/download/experimental-latest/Wavee.Experimental.x64.appinstaller">
+    <img src="assets/download-msix.svg" alt="Download for Windows - signed MSIX installer" width="260">
+  </a><br>
+  <sub>Windows on ARM? Use the <a href="https://github.com/christosk92/WaveeMusic/releases/download/experimental-latest/Wavee.Experimental.arm64.appinstaller">ARM64 installer</a>.</sub>
+</p>
+
 <img width="1306" height="871" alt="image" src="https://github.com/user-attachments/assets/68608f86-7fb9-46ad-99c5-c5a94220ad71" />
 
 
@@ -99,12 +106,16 @@ A **Spotify Premium** account is required, and the app is intended for personal 
 
 ## Download the alpha
 
-The experimental alpha ships as a signed MSIX from
-[GitHub Releases](https://github.com/christosk92/WaveeMusic/releases) —
-grab the matching `Wavee.UI.WinUI_{package-version}_{arch}.msix` for your machine,
-or install from `Wavee.Experimental.<arch>.appinstaller` to get silent background
-auto-updates. See [ALPHA.md](ALPHA.md) for system requirements, installation steps,
-known limitations, and how to file a useful bug report.
+The badge above downloads Wavee's experimental `.appinstaller` file for x64
+Windows. Open it and Windows App Installer will download the signed MSIX
+package, then keep it on the background auto-update channel. ARM64 builds are
+available from the ARM64 installer link above and from the release assets.
+
+If you want the raw package instead, download the matching
+`Wavee.UI.WinUI_{package-version}_{arch}.msix` asset from
+[GitHub Releases](https://github.com/christosk92/WaveeMusic/releases). See
+[ALPHA.md](ALPHA.md) for system requirements, installation steps, known
+limitations, and how to file a useful bug report.
 
 > A Spotify **Premium** account is required. Wavee shows a non-dismissible
 > banner if you sign in with a Free account.

--- a/assets/download-msix.svg
+++ b/assets/download-msix.svg
@@ -1,14 +1,40 @@
-<svg width="640" height="180" viewBox="0 0 640 180" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
-  <title id="title">Download for Windows</title>
-  <desc id="desc">Signed MSIX installer download badge for WaveeMusic.</desc>
-  <rect x="2.5" y="2.5" width="635" height="175" rx="24" fill="#0B0B0B"/>
-  <rect x="2.5" y="2.5" width="635" height="175" rx="24" stroke="#707070" stroke-width="5"/>
-  <g transform="translate(32 46)">
-    <rect width="88" height="88" rx="10" fill="#0078D4"/>
-    <path d="M17 31L44 16L71 31L44 46L17 31Z" fill="#FFFFFF"/>
-    <path d="M17 37L41 50V74L17 60V37Z" fill="#FFFFFF"/>
-    <path d="M47 50L71 37V60L47 74V50Z" fill="#FFFFFF"/>
+<svg width="600" height="180" viewBox="0 0 600 180" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Download Wavee — signed MSIX</title>
+  <desc id="desc">Download the signed MSIX package of WaveeMusic for Windows.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="180" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1488DB"/>
+      <stop offset="1" stop-color="#0A6CC0"/>
+    </linearGradient>
+    <mask id="wv" maskContentUnits="userSpaceOnUse">
+      <rect width="1024" height="1024" fill="white"/>
+      <path fill="black" d="M0 305.5C2.07836 301.996 4.67019 293.611 6.33174 289.587C19.2036 258.412 49.5041 237.841 83.6085 247.704C113.823 256.442 133.338 282.582 141.716 311.976C147.123 330.945 146.338 350.855 146.389 370.407L146.452 413.469L146.468 633.736L146.311 690.046C146.129 710.251 145.355 728.493 148.152 748.55C151.23 771.143 158.423 792.981 169.374 812.981C190.287 850.661 222.334 879.319 264.312 891.243C300.683 901.329 339.561 896.727 372.572 878.427C410.695 857.156 438.986 818.509 451.67 777.104C462.277 742.476 460.46 703.823 460.478 667.826L460.509 584.941L460.533 370.913L460.461 327.854C460.333 297.257 456.793 264.726 488.526 247.343C500.495 240.828 514.584 239.412 527.61 243.414C545.204 248.784 557.511 262.649 562.328 280.104C566.222 294.215 564.996 313.99 564.98 329.1L564.942 376.494L564.666 619.52L564.904 688.674C564.909 707.575 564.253 728.301 566.706 746.869C569.609 769.263 576.517 790.952 587.098 810.9C606.793 847.763 640.532 878.942 681.009 890.848C717.909 901.702 756.223 897.088 790.006 878.859C836.272 853.896 866.845 806.876 875.814 755.648C880.064 731.378 879.12 706.408 879.064 681.87L879.022 603.693L879.044 406.791L879.008 367.847C878.994 347.303 878.439 328.432 884.533 308.372C891.626 285.546 906.653 264.127 927.91 252.79C961.694 234.772 999.127 249.603 1016.23 282.61C1018.85 287.672 1020.93 293.266 1023.53 298.197L1024 299.084L1024 818.781L1024 1024L822.304 1024L202.706 1024L0 1024L0 816.462L0 305.5Z"/>
+      <path fill="black" d="M0 0L204.715 0L824.429 0L1024 0L1024 205.773C1022.85 201.442 1022.24 194.19 1021.53 189.529C1019.82 178.312 1018 168.732 1014.23 157.985C999.235 148.611 989.396 142.8 971.561 139.358C874.435 120.61 790.524 203.55 775.821 294.625C772.125 317.519 772.922 342.512 772.948 365.691L772.985 450.656L772.949 652.478L772.987 698.272C773.006 726.226 775.384 750.707 752.058 770.566C723.716 795.41 682.518 778.822 672.37 744.328C667.48 727.711 668.964 708.392 668.992 691.04L669.03 646.8L669.079 401.644L669.084 331.162C669.081 310.723 669.627 290.214 666.454 269.965C662.762 245.914 654.102 222.895 641.027 202.374C594.866 130.494 506.601 105.56 432.993 153.013C400.89 174.018 377.043 205.484 365.5 242.07C352.981 281.572 355.426 314.584 355.491 355.254L355.533 438.109L355.528 652.193L355.548 695.889C355.7 725.064 358.242 756.854 329.667 774.799C318.672 781.835 305.297 784.12 292.591 781.133C273.557 776.606 260.115 761.042 254.864 742.742C250.784 728.52 252.01 709.052 252.039 693.884L252.057 650.429L252.051 421.515L252.048 356.332C252.044 336.399 252.526 316.197 249.354 296.46C245.097 269.572 235.449 243.821 220.99 220.755C186.324 165.139 123.806 127.686 56.7192 138.117C39.1231 140.853 25.0859 147.659 10.2059 157.018C7.36044 166.406 4.72074 175.41 2.99609 185.09C1.80817 191.757 1.80097 199.439 0 205.781L0 0Z"/>
+    </mask>
+  </defs>
+
+  <rect x="0" y="0" width="600" height="180" rx="30" fill="url(#bg)"/>
+
+  <g transform="translate(40 28)">
+    <ellipse cx="70" cy="120" rx="52" ry="10" fill="#000000" opacity="0.18"/>
+
+    <polygon points="24,52 70,29 56,11 10,34" fill="#FFFFFF" stroke="#C9D6E2" stroke-width="1.2" stroke-linejoin="round"/>
+    <polygon points="70,29 116,52 130,34 84,11" fill="#FFFFFF" stroke="#C9D6E2" stroke-width="1.2" stroke-linejoin="round"/>
+    <polygon points="70,75 24,52 8,38 54,61" fill="#EDF3F8" stroke="#C9D6E2" stroke-width="1.2" stroke-linejoin="round"/>
+    <polygon points="116,52 70,75 86,61 132,38" fill="#EDF3F8" stroke="#C9D6E2" stroke-width="1.2" stroke-linejoin="round"/>
+
+    <polygon points="70,29 116,52 70,75 24,52" fill="#BAC9D8"/>
+
+    <polygon points="24,52 70,75 70,109 24,86" fill="#DCE7F0" stroke="#C9D6E2" stroke-width="1.2" stroke-linejoin="round"/>
+    <polygon points="70,75 116,52 116,86 70,109" fill="#FFFFFF" stroke="#C9D6E2" stroke-width="1.2" stroke-linejoin="round"/>
+
+    <!-- Wavee wave-W mark, skewed onto the front-right face -->
+    <g transform="matrix(0.027852,-0.013926,0,0.021914,78.74,76.41)">
+      <rect width="1024" height="1024" fill="#1DB954" mask="url(#wv)"/>
+    </g>
   </g>
-  <text x="146" y="66" fill="#FFFFFF" font-family="Segoe UI, Arial, sans-serif" font-size="23" font-weight="600" letter-spacing=".7">SIGNED MSIX INSTALLER</text>
-  <text x="146" y="123" fill="#FFFFFF" font-family="Segoe UI, Arial, sans-serif" font-size="43" font-weight="600">Download for Windows</text>
+
+  <text x="240" y="116" font-family="Segoe UI, Arial, sans-serif" fill="#FFFFFF">
+    <tspan font-size="86" font-weight="800" letter-spacing="1">MSIX</tspan><tspan dx="12" font-size="30" font-weight="600" fill="#D6E8FB">Wavee</tspan>
+  </text>
 </svg>

--- a/assets/download-msix.svg
+++ b/assets/download-msix.svg
@@ -1,0 +1,14 @@
+<svg width="640" height="180" viewBox="0 0 640 180" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Download for Windows</title>
+  <desc id="desc">Signed MSIX installer download badge for WaveeMusic.</desc>
+  <rect x="2.5" y="2.5" width="635" height="175" rx="24" fill="#0B0B0B"/>
+  <rect x="2.5" y="2.5" width="635" height="175" rx="24" stroke="#707070" stroke-width="5"/>
+  <g transform="translate(32 46)">
+    <rect width="88" height="88" rx="10" fill="#0078D4"/>
+    <path d="M17 31L44 16L71 31L44 46L17 31Z" fill="#FFFFFF"/>
+    <path d="M17 37L41 50V74L17 60V37Z" fill="#FFFFFF"/>
+    <path d="M47 50L71 37V60L47 74V50Z" fill="#FFFFFF"/>
+  </g>
+  <text x="146" y="66" fill="#FFFFFF" font-family="Segoe UI, Arial, sans-serif" font-size="23" font-weight="600" letter-spacing=".7">SIGNED MSIX INSTALLER</text>
+  <text x="146" y="123" fill="#FFFFFF" font-family="Segoe UI, Arial, sans-serif" font-size="43" font-weight="600">Download for Windows</text>
+</svg>


### PR DESCRIPTION
## Summary

- Adds a Microsoft Store-style local SVG badge for direct signed MSIX installation.
- Points the badge at the rolling `experimental-latest` x64 `.appinstaller` asset so Windows App Installer pulls the signed package and keeps alpha installs on the auto-update channel.
- Keeps ARM64 available through a smaller adjacent installer link and clarifies the alpha download section.

## Validation

- `git diff --check --cached`