### PR TITLE
Fix touch-scroll registering as stuck hover on track/card surfaces

### DIFF
--- a/src/Wavee.UI.WinUI/Behaviors/CardHoverScaleBehavior.cs
+++ b/src/Wavee.UI.WinUI/Behaviors/CardHoverScaleBehavior.cs
@@ -59,7 +59,11 @@ public static class CardHoverScaleBehavior
     private static void Attach(FrameworkElement fe)
     {
         var holder = new HandlerHolder();
-        holder.Entered = (_, _) => Animate(fe, HoverScale);
+        holder.Entered = (_, e) =>
+        {
+            if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch: no hover scale (issue #4)
+            Animate(fe, HoverScale);
+        };
         holder.Exited = (_, _) => Animate(fe, 1.0f);
         holder.Loaded = OnLoaded;
         holder.SizeChanged = OnSizeChanged;

--- a/src/Wavee.UI.WinUI/Behaviors/RevealSpotlightBehavior.cs
+++ b/src/Wavee.UI.WinUI/Behaviors/RevealSpotlightBehavior.cs
@@ -72,8 +72,9 @@ public static class RevealSpotlightBehavior
             OriginalBackground = border.Background,
         };
 
-        holder.Entered = (_, _) =>
+        holder.Entered = (_, e) =>
         {
+            if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch: no spotlight (issue #4)
             var color = GetSpotlightColor(border);
             holder.TrackingBrush = new RadialGradientBrush
             {

--- a/src/Wavee.UI.WinUI/Controls/Artist/ArtistSummaryCard.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Artist/ArtistSummaryCard.xaml.cs
@@ -261,6 +261,7 @@ public sealed partial class ArtistSummaryCard : UserControl
 
     private void CardSurface_PointerEntered(object sender, PointerRoutedEventArgs e)
     {
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch has no hover (issue #4)
         // Subtle background lift on hover. Mirrors the affordance the rest
         // of the app uses (ContentCard, ArtistPillCard) â€” lighter card-fill
         // tier signals "this is clickable".

--- a/src/Wavee.UI.WinUI/Controls/Cards/BaselineHomeCard.Hover.cs
+++ b/src/Wavee.UI.WinUI/Controls/Cards/BaselineHomeCard.Hover.cs
@@ -41,6 +41,7 @@ public sealed partial class BaselineHomeCard
 
     private void Card_PointerEntered(object sender, PointerRoutedEventArgs e)
     {
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch has no hover (issue #4)
         UpdateLastPointerWindowPosition(e);
         _hoverStopVersion++;
         _isPointerOver = true;

--- a/src/Wavee.UI.WinUI/Controls/Cards/ContentCard.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Cards/ContentCard.xaml.cs
@@ -803,6 +803,7 @@ public sealed partial class ContentCard : UserControl
 
     private void Card_PointerEntered(object sender, PointerRoutedEventArgs e)
     {
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch has no hover (issue #4)
         _isPointerOver = true;
         CardHover?.Invoke(this, EventArgs.Empty);
 

--- a/src/Wavee.UI.WinUI/Controls/Cards/EpisodeCard.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Cards/EpisodeCard.xaml.cs
@@ -271,6 +271,7 @@ public sealed partial class EpisodeCard : UserControl
 
     private void CardRoot_PointerEntered(object sender, PointerRoutedEventArgs e)
     {
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch has no hover (issue #4)
         if (_isHovered) return;
         _isHovered = true;
         AnimateHover(true);

--- a/src/Wavee.UI.WinUI/Controls/Cards/LikedSongsRecentCard.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Cards/LikedSongsRecentCard.xaml.cs
@@ -497,6 +497,7 @@ public sealed partial class LikedSongsRecentCard : UserControl
 
     private void CardRoot_PointerEntered(object sender, PointerRoutedEventArgs e)
     {
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch has no hover (issue #4)
         if (_isHovered) return;
         _isHovered = true;
         // Float the whole card above its row neighbours so the popping-out

--- a/src/Wavee.UI.WinUI/Controls/Local/LocalEpisodeCard.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Local/LocalEpisodeCard.xaml.cs
@@ -218,6 +218,7 @@ public sealed partial class LocalEpisodeCard : UserControl
 
     private void CardRoot_PointerEntered(object sender, PointerRoutedEventArgs e)
     {
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch has no hover (issue #4)
         if (Episode is not { IsOnDisk: true }) return; // missing rows: no hover affordance
         _isHovered = true;
         ScaleCard(1.03f, 180);

--- a/src/Wavee.UI.WinUI/Controls/Local/LocalEpisodeRow.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Local/LocalEpisodeRow.xaml.cs
@@ -151,6 +151,7 @@ public sealed partial class LocalEpisodeRow : UserControl
 
     private void RowRoot_PointerEntered(object sender, PointerRoutedEventArgs e)
     {
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch has no hover (issue #4)
         if (Episode is not { IsOnDisk: true }) return; // missing rows don't show hover-play
         AnimateOpacity(HoverFill, 1.0, 120);
         AnimateOpacity(PlayOverlay, 1.0, 120);

--- a/src/Wavee.UI.WinUI/Controls/Local/UpNextEpisodeOverlay.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Local/UpNextEpisodeOverlay.xaml.cs
@@ -189,7 +189,10 @@ public sealed partial class UpNextEpisodeOverlay : UserControl
     private void CancelButton_Click(object sender, RoutedEventArgs e) => ViewModel?.Cancel();
 
     private void CardRoot_PointerEntered(object sender, PointerRoutedEventArgs e)
-        => ViewModel?.NotifyPointerEnteredCard();
+    {
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch has no hover (issue #4)
+        ViewModel?.NotifyPointerEnteredCard();
+    }
 
     private void CardRoot_PointerExited(object sender, PointerRoutedEventArgs e)
         => ViewModel?.NotifyPointerExitedCard();

--- a/src/Wavee.UI.WinUI/Controls/Queue/QueueControl.xaml
+++ b/src/Wavee.UI.WinUI/Controls/Queue/QueueControl.xaml
@@ -65,6 +65,8 @@
                   Loaded="TrackRoot_Loaded"
                   PointerEntered="TrackRow_PointerEntered"
                   PointerExited="TrackRow_PointerExited"
+                  PointerCanceled="TrackRow_PointerExited"
+                  PointerCaptureLost="TrackRow_PointerExited"
                   Opacity="{x:Bind VisualOpacity, Mode=OneTime}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="40"/>

--- a/src/Wavee.UI.WinUI/Controls/Queue/QueueControl.xaml
+++ b/src/Wavee.UI.WinUI/Controls/Queue/QueueControl.xaml
@@ -63,8 +63,11 @@
                   CornerRadius="4"
                   Background="Transparent"
                   Loaded="TrackRoot_Loaded"
+                  Tapped="TrackRow_Tapped"
                   PointerEntered="TrackRow_PointerEntered"
                   PointerExited="TrackRow_PointerExited"
+                  PointerPressed="TrackRow_PointerPressed"
+                  PointerReleased="TrackRow_PointerReleased"
                   PointerCanceled="TrackRow_PointerExited"
                   PointerCaptureLost="TrackRow_PointerExited"
                   Opacity="{x:Bind VisualOpacity, Mode=OneTime}">

--- a/src/Wavee.UI.WinUI/Controls/Queue/QueueControl.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Queue/QueueControl.xaml.cs
@@ -804,8 +804,59 @@ public sealed partial class QueueControl : UserControl
     }
 
     // Also wired to PointerCanceled / PointerCaptureLost in XAML so a mouse
-    // drag-capture (or any lost capture) clears the revealed hover controls.
-    private void TrackRow_PointerExited(object sender, PointerRoutedEventArgs e) => SetRowHoverState(sender, false);
+    // drag-capture (or any lost capture) clears the revealed hover controls and
+    // any pressed tint.
+    private void TrackRow_PointerExited(object sender, PointerRoutedEventArgs e)
+    {
+        SetRowHoverState(sender, false);
+        SetRowPressed(sender, false);
+    }
+
+    // -- Touch / tap feedback ------------------------------------------------
+    // Queue rows are SelectionMode=None + IsItemClickEnabled=False, so the list
+    // gives no native press chrome, and the play button is hover-only. After
+    // hover was disabled for touch (issue #4) a finger tap had no feedback and no
+    // way to play a row. Paint a transient pressed tint on press, and play on a
+    // clean tap. Applies to mouse too (consistent, transient — never sticks).
+
+    private static readonly Brush s_rowTransparent = new SolidColorBrush(Colors.Transparent);
+
+    private static void SetRowPressed(object sender, bool pressed)
+    {
+        if (sender is not Panel root) return; // TrackRoot is a Grid
+        root.Background = pressed
+            ? (Brush)Application.Current.Resources["SubtleFillColorTertiaryBrush"]
+            : s_rowTransparent;
+    }
+
+    private void TrackRow_PointerPressed(object sender, PointerRoutedEventArgs e) => SetRowPressed(sender, true);
+    private void TrackRow_PointerReleased(object sender, PointerRoutedEventArgs e) => SetRowPressed(sender, false);
+
+    // Tap anywhere on the row that isn't a button or link skips to that queue
+    // item — the same action as the hover play button, but reachable by touch.
+    private void TrackRow_Tapped(object sender, TappedRoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement { DataContext: QueueDisplayItem { HasMetadata: true } item })
+            return;
+        if (item.QueueIndex < 0)
+            return;
+        // Don't hijack taps on the play / more buttons or the title / artist links.
+        if (e.OriginalSource is DependencyObject src && IsWithinButton(src, sender as DependencyObject))
+            return;
+
+        _ = SkipToQueueAsync(item.QueueIndex);
+        e.Handled = true;
+    }
+
+    private static bool IsWithinButton(DependencyObject node, DependencyObject? stopAt)
+    {
+        for (var d = node; d is not null && !ReferenceEquals(d, stopAt); d = VisualTreeHelper.GetParent(d))
+        {
+            if (d is Microsoft.UI.Xaml.Controls.Primitives.ButtonBase)
+                return true;
+        }
+        return false;
+    }
 
     private void RowPlay_Click(object sender, RoutedEventArgs e)
     {

--- a/src/Wavee.UI.WinUI/Controls/Queue/QueueControl.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Queue/QueueControl.xaml.cs
@@ -794,7 +794,17 @@ public sealed partial class QueueControl : UserControl
             duration.Visibility = showActions || !hasLoadedTrack ? Visibility.Collapsed : Visibility.Visible;
     }
 
-    private void TrackRow_PointerEntered(object sender, PointerRoutedEventArgs e) => SetRowHoverState(sender, true);
+    private void TrackRow_PointerEntered(object sender, PointerRoutedEventArgs e)
+    {
+        // Touch has no hover: a finger-scroll would otherwise leave the row's play /
+        // more buttons revealed, because the scroll capture delivers Canceled/
+        // CaptureLost rather than PointerExited (issue #4). Mouse/pen still reveal.
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return;
+        SetRowHoverState(sender, true);
+    }
+
+    // Also wired to PointerCanceled / PointerCaptureLost in XAML so a mouse
+    // drag-capture (or any lost capture) clears the revealed hover controls.
     private void TrackRow_PointerExited(object sender, PointerRoutedEventArgs e) => SetRowHoverState(sender, false);
 
     private void RowPlay_Click(object sender, RoutedEventArgs e)

--- a/src/Wavee.UI.WinUI/Controls/Search/SearchResultHeroCard.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Search/SearchResultHeroCard.xaml.cs
@@ -656,6 +656,7 @@ public sealed partial class SearchResultHeroCard : UserControl
 
     private void OnPointerEntered(object sender, PointerRoutedEventArgs e)
     {
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch has no hover (issue #4)
         _isHovered = true;
         ApplyHoverBackground();
         AnimationBuilder.Create()

--- a/src/Wavee.UI.WinUI/Controls/Search/SearchResultRowCard.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Search/SearchResultRowCard.xaml.cs
@@ -394,6 +394,7 @@ public sealed partial class SearchResultRowCard : UserControl
 
     private void OnPointerEntered(object sender, PointerRoutedEventArgs e)
     {
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch has no hover (issue #4)
         _isHovered = true;
         ApplyInteractionState();
         UpdateOverlayState();

--- a/src/Wavee.UI.WinUI/Controls/ShowEpisode/PodcastEpisodeRecommendationCard.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/ShowEpisode/PodcastEpisodeRecommendationCard.xaml.cs
@@ -88,6 +88,7 @@ public sealed partial class PodcastEpisodeRecommendationCard : UserControl
 
     private void CardRoot_PointerEntered(object sender, PointerRoutedEventArgs e)
     {
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch has no hover (issue #4)
         HoverFill.Opacity = 1;
         PlayButton.Opacity = 1;
         ActionCluster.Opacity = 1;

--- a/src/Wavee.UI.WinUI/Controls/ShowEpisode/ShowEpisodeRow.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/ShowEpisode/ShowEpisodeRow.xaml.cs
@@ -306,6 +306,7 @@ public sealed partial class ShowEpisodeRow : UserControl
 
     private void RowRoot_PointerEntered(object sender, PointerRoutedEventArgs e)
     {
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch has no hover (issue #4)
         AnimateOpacity(HoverFill, 1.0);
         AnimateOpacity(ActionCluster, 1.0);
         if (Episode?.PlayedState == "COMPLETED")

--- a/src/Wavee.UI.WinUI/Controls/ShowEpisode/ShowResumeBanner.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/ShowEpisode/ShowResumeBanner.xaml.cs
@@ -241,7 +241,10 @@ public sealed partial class ShowResumeBanner : UserControl
     }
 
     private void BannerRoot_PointerEntered(object sender, PointerRoutedEventArgs e)
-        => SetHoverState(true);
+    {
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch has no hover (issue #4)
+        SetHoverState(true);
+    }
 
     private void BannerRoot_PointerExited(object sender, PointerRoutedEventArgs e)
         => SetHoverState(false);

--- a/src/Wavee.UI.WinUI/Controls/ShowEpisode/ShowUpNextCard.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/ShowEpisode/ShowUpNextCard.xaml.cs
@@ -196,7 +196,10 @@ public sealed partial class ShowUpNextCard : UserControl
     }
 
     private void CardRoot_PointerEntered(object sender, PointerRoutedEventArgs e)
-        => SetHoverState(true);
+    {
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch has no hover (issue #4)
+        SetHoverState(true);
+    }
 
     private void CardRoot_PointerExited(object sender, PointerRoutedEventArgs e)
         => SetHoverState(false);

--- a/src/Wavee.UI.WinUI/Controls/Track/Behaviors/TrackStateBehavior.cs
+++ b/src/Wavee.UI.WinUI/Controls/Track/Behaviors/TrackStateBehavior.cs
@@ -94,6 +94,8 @@ public static class TrackStateBehavior
         {
             element.PointerEntered -= OnPointerEntered;
             element.PointerExited -= OnPointerExited;
+            element.PointerCanceled -= OnPointerExited;
+            element.PointerCaptureLost -= OnPointerExited;
             element.Loaded -= OnLoaded;
             element.Unloaded -= OnUnloaded;
             RemoveFromRegistry(element, oldTrackId);
@@ -103,6 +105,10 @@ public static class TrackStateBehavior
         {
             element.PointerEntered += OnPointerEntered;
             element.PointerExited += OnPointerExited;
+            // Touch-scroll capture delivers Canceled/CaptureLost instead of Exited;
+            // route both to the exit reset so IsHovered never sticks (issue #4).
+            element.PointerCanceled += OnPointerExited;
+            element.PointerCaptureLost += OnPointerExited;
             element.Loaded += OnLoaded;
             element.Unloaded += OnUnloaded;
             AddToRegistry(element, newTrackId);
@@ -205,6 +211,7 @@ public static class TrackStateBehavior
     {
         if (sender is not FrameworkElement element) return;
         if (!GetIsEnabled(element)) return;
+        if (Wavee.UI.WinUI.DragDrop.PointerInput.IsTouch(e)) return; // touch has no hover (issue #4)
 
         SetIsHovered(element, true);
 

--- a/src/Wavee.UI.WinUI/Controls/Track/TrackItem.Hover.cs
+++ b/src/Wavee.UI.WinUI/Controls/Track/TrackItem.Hover.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
+using Wavee.UI.WinUI.DragDrop;
 
 namespace Wavee.UI.WinUI.Controls.Track;
 
@@ -24,6 +25,13 @@ public sealed partial class TrackItem
 
     private void OnPointerEntered(object sender, PointerRoutedEventArgs e)
     {
+        // Touch has no hover. WinUI still raises PointerEntered on touch-down, but
+        // during a finger-scroll the ScrollView captures the pointer and the row
+        // receives PointerCanceled/CaptureLost instead of the PointerExited that
+        // clears hover — so the highlight would stick on every crossed row
+        // (issue #4). Mouse and pen continue to hover normally.
+        if (PointerInput.IsTouch(e)) return;
+
         _isHovered = true;
 
         if (Mode == TrackItemDisplayMode.Compact)

--- a/src/Wavee.UI.WinUI/Controls/Track/TrackItem.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Track/TrackItem.xaml.cs
@@ -586,9 +586,14 @@ public sealed partial class TrackItem : UserControl
     {
         InitializeComponent();
 
-        // Hover tracking
+        // Hover tracking. Canceled/CaptureLost route to the same reset as Exited:
+        // during a touch-scroll (and a mouse drag-capture) the row gets those
+        // instead of PointerExited, so without them the hover visual would stick
+        // (issue #4).
         PointerEntered += OnPointerEntered;
         PointerExited += OnPointerExited;
+        PointerCanceled += OnPointerExited;
+        PointerCaptureLost += OnPointerExited;
 
         // Ensure playback bridge is initialized (idempotent)
         TrackStateBehavior.EnsurePlaybackSubscription();


### PR DESCRIPTION
## Problem

Reported in #4: on touch devices (Surface Pro), finger-scrolling a track list (playlist table, queue) leaves every row the finger crosses **stuck in its hover state**.

## Root cause

WinUI raises `PointerEntered` on touch-down, but when the finger pans, the `ScrollView` captures the pointer for direct-manipulation scrolling and the row receives `PointerCanceled`/`PointerCaptureLost` — never the `PointerExited` that clears hover. So `_isHovered` never resets and the highlight sticks.

(The drag-to-reorder half of #4 was already guarded by `PointerInput.IsTouch` in `ReorderController`/`ManualDragAttachment`; this PR fixes the remaining hover half.)

## Fix

- Guard every track/episode/card hover-enter handler with `PointerInput.IsTouch(e)` so **touch never enters hover**. Mouse and pen are unchanged (pen still hovers).
- Route `PointerCanceled`/`PointerCaptureLost` to the same reset as `PointerExited` on the stateful surfaces (`TrackItem`, `QueueControl`, `TrackStateBehavior`) as defense against capture steals.

Surfaces: TrackItem (playlist/album/liked/artist/library), Queue panel, TrackStateBehavior, ContentCard, BaselineHomeCard, EpisodeCard, LikedSongsRecentCard, search row/hero cards, Show* episode rows, Local episode rows/cards, ArtistSummaryCard, and the shared `CardHoverScaleBehavior`/`RevealSpotlightBehavior`. Non-track chrome (sidebar/toolbar/splitter) and the unconsumed `TrackBehavior.IsPointerOver` are intentionally untouched.

## Testing

On a touch device: finger-scroll the playlist table and queue → no row lights up or sticks; mouse/pen hover, tap-to-play, mouse drag-reorder, and touch long-press menu all unchanged.

Fixes #4