### PR TITLE
Fix playlist create/edit state (track seed, cover sync, cover leak, recommended add)

### DIFF
--- a/src/Wavee.UI.WinUI/Controls/TrackDataGrid/TrackDataGrid.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/TrackDataGrid/TrackDataGrid.xaml.cs
@@ -1895,9 +1895,6 @@ public sealed partial class TrackDataGrid : UserControl, IDisposable, IReorderHo
         _reorderSettleUntilTicks = settleUntil;
         Behaviors.StaggeredEntrance.SuppressUntil(settleUntil);
 
-        var draggedTitle = from >= 0 && from < _visibleRows.Count && _visibleRows[from] is ITrackItem dt
-            ? dt.Title : "?";
-
         // PlaylistTrackListViewModel.ReorderTracksAsync does the gap→insert mapping,
         // OriginalIndex renumber, optimistic reset, and backend write — and now SKIPS
         // the redundant re-realize on every matching dealer echo (idempotent reproject),
@@ -1919,64 +1916,7 @@ public sealed partial class TrackDataGrid : UserControl, IDisposable, IReorderHo
         // Safety net for any residual transient: hide only the still-mis-placed rows until
         // they land (never the whole list), so neither the overlap nor a blank ever shows.
         EnsureReorderSettleMask();
-        StartReorderOverlapSnapshot(draggedTitle, from, toGapSlot);
         return true;
-    }
-
-    // ── Reorder overlap diagnostics (temporary) ─────────────────────────────
-    // Logs EVERY realized container's bound title + arranged Y + both opacity channels
-    // for a short window after the drop, sorted by Y, flagging any two containers that
-    // sit within half a row pitch of each other (the visible overlap). This shows which
-    // two rows double-paint at one Y and which is the stale one.
-    private void StartReorderOverlapSnapshot(string draggedTitle, int from, int slot)
-    {
-        System.Diagnostics.Debug.WriteLine(
-            $"[odbg] === commit from={from} slot={slot} dragged='{draggedTitle}' visibleCount={_visibleRows.Count} ===");
-        var frame = 0;
-        System.EventHandler<object>? handler = null;
-        handler = (_, _) =>
-        {
-            frame++;
-            LogReorderContainers(frame);
-            if (frame >= 5 || _disposed)
-                Microsoft.UI.Xaml.Media.CompositionTarget.Rendering -= handler;
-        };
-        Microsoft.UI.Xaml.Media.CompositionTarget.Rendering += handler;
-    }
-
-    private void LogReorderContainers(int frame)
-    {
-        try
-        {
-            var root = ((IReorderHost)this).ReorderCoordinateRoot;
-            var host = (DependencyObject?)_rowsRepeater ?? RowsItemsView;
-            var containers = new List<ItemContainer>();
-            CollectDescendants(host, containers);
-            var rows = new List<(string title, int idx, double top, double offY, double cOp, double vOp, bool vis, double fTY)>();
-            foreach (var c in containers)
-            {
-                var item = FindDescendant<Track.TrackItem>(c)?.Track;
-                var title = item?.Title ?? "<null>";
-                double top;
-                try { top = c.TransformToVisual(root).TransformPoint(new Windows.Foundation.Point(0, 0)).Y; }
-                catch { continue; }
-                var v = Microsoft.UI.Xaml.Hosting.ElementCompositionPreview.GetElementVisual(c);
-                v.Properties.TryGetVector3("Translation", out var facade);
-                var idx = item is null ? -1 : _visibleRows.IndexOf(item);
-                rows.Add((title.Length > 14 ? title[..14] : title, idx, top, v.Offset.Y, c.Opacity, v.Opacity, v.IsVisible, facade.Y));
-            }
-            rows.Sort((a, b) => a.top.CompareTo(b.top));
-            System.Diagnostics.Debug.WriteLine($"[odbg] f{frame,-2} realized={rows.Count}");
-            for (int i = 0; i < rows.Count; i++)
-            {
-                var r = rows[i];
-                var overlap = i > 0 && !double.IsNaN(r.top) && !double.IsNaN(rows[i - 1].top)
-                              && Math.Abs(r.top - rows[i - 1].top) < 26 ? " <<OVERLAP" : "";
-                System.Diagnostics.Debug.WriteLine(
-                    $"[odbg]   '{r.title,-14}' i={r.idx,-2} top={r.top,7:F0} off={r.offY,7:F0} cO={r.cOp:F2} vO={r.vOp:F2} vis={(r.vis ? 1 : 0)} fY={r.fTY,6:F0}{overlap}");
-            }
-        }
-        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[odbg] f{frame} err {ex.Message}"); }
     }
 
     private static void CollectDescendants(DependencyObject root, List<ItemContainer> sink)

--- a/src/Wavee.UI.WinUI/ViewModels/Playlist/PlaylistMutationCoordinator.cs
+++ b/src/Wavee.UI.WinUI/ViewModels/Playlist/PlaylistMutationCoordinator.cs
@@ -418,7 +418,12 @@ public sealed partial class PlaylistMutationCoordinator : ObservableObject
     private async Task AddRecommendationAsync(RecommendedTrackResult? rec)
     {
         var playlistId = PlaylistId;
-        if (rec is null || string.IsNullOrEmpty(rec.Uri) || string.IsNullOrEmpty(playlistId)) return;
+        if (rec is null || string.IsNullOrEmpty(rec.Uri) || string.IsNullOrEmpty(playlistId))
+        {
+            _logger?.LogDebug("AddRecommendation skipped: recNull={RecNull}, uri='{Uri}', playlist='{Playlist}'",
+                rec is null, rec?.Uri ?? "<null>", playlistId);
+            return;
+        }
         try
         {
             await _playlistMutationService.AddTracksToPlaylistAsync(playlistId, new[] { rec.Uri })

--- a/src/Wavee.UI.WinUI/Views/PlaylistPage.xaml
+++ b/src/Wavee.UI.WinUI/Views/PlaylistPage.xaml
@@ -934,8 +934,7 @@
                                                 BorderThickness="1"
                                                 VerticalAlignment="Center"
                                                 Margin="8,0,0,0"
-                                                Command="{Binding ElementName=PageRoot, Path=ViewModel.Mutations.AddRecommendationCommand}"
-                                                CommandParameter="{x:Bind}"
+                                                Click="RecommendationAdd_Click"
                                                 ToolTipService.ToolTip="Add to this playlist">
                                             <FontIcon Glyph="&#xE710;" FontSize="14"/>
                                         </Button>

--- a/src/Wavee.UI.WinUI/Views/PlaylistPage.xaml.cs
+++ b/src/Wavee.UI.WinUI/Views/PlaylistPage.xaml.cs
@@ -812,6 +812,11 @@ public sealed partial class PlaylistPage : UserControl, ITabBarItemContent, IPag
             "PlaylistPage.LoadParameter: parameter type={Type}, value={Value}",
             parameter?.GetType().FullName ?? "<null>", parameter);
 
+        // Drop any cover-edit preview overlay stranded from a previous playlist
+        // (e.g. navigated away mid-upload before StartCoverEditAsync's finally
+        // ran) so it can't render on top of this playlist's cover.
+        ClearCoverPreview();
+
         // Reset shimmer / content visual state for the fresh load — mirrors
         // ArtistPage / AlbumPage so the next playlist fades in cleanly instead
         // of inheriting the previous playlist's already-shown content layer.
@@ -1409,10 +1414,15 @@ public sealed partial class PlaylistPage : UserControl, ITabBarItemContent, IPag
         }
         catch
         {
-            ClearCoverPreview();
+            // ChangeCoverCommand already toasts on failure; nothing extra here.
         }
         finally
         {
+            // Always drop the local preview overlay — on success AND failure.
+            // Leaving it set strands the uploaded bitmap on this reused
+            // PlaylistPage instance, so it would render on top of every other
+            // playlist's cover after navigation (the global cover-leak bug).
+            ClearCoverPreview();
             CoverUploadRing.IsActive = false;
             CoverUploadRing.Visibility = Visibility.Collapsed;
         }
@@ -1465,8 +1475,22 @@ public sealed partial class PlaylistPage : UserControl, ITabBarItemContent, IPag
 
     private void ClearCoverPreview()
     {
+        if (CoverPreviewImage is null) return;
         CoverPreviewImage.Source = null;
         CoverPreviewImage.Visibility = Visibility.Collapsed;
+    }
+
+    // Recommended Songs "+" — handled in code-behind so the command resolves
+    // against the page's ViewModel. An ElementName binding to PageRoot does NOT
+    // resolve inside the recommendations ItemsRepeater item template (separate
+    // namescope), which left the button inert.
+    private void RecommendationAdd_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as FrameworkElement)?.DataContext is not Wavee.UI.Contracts.RecommendedTrackResult rec)
+            return;
+        var cmd = ViewModel?.Mutations?.AddRecommendationCommand;
+        if (cmd?.CanExecute(rec) == true)
+            cmd.Execute(rec);
     }
 
     // ── Overflow menu (per-permission) ───────────────────────────────────────

--- a/src/Wavee.UI/Services/Playlists/PlaylistMutationService.cs
+++ b/src/Wavee.UI/Services/Playlists/PlaylistMutationService.cs
@@ -146,16 +146,29 @@ public sealed class PlaylistMutationService : IPlaylistMutationService, IPlaylis
             _logger?.LogWarning(ex, "CreatePlaylistAsync: post-create rename failed for {Uri}", newUri);
         }
 
-        // Tracks-from-selection path is a follow-up — needs ChangePlaylistAsync against
-        // the new URI with the freshly returned revision. Out of scope for this cut.
+        // Step 4: seed the originating tracks ("Add to playlist → New playlist"
+        // from a track selection). Reuses the standard add path so the change
+        // rides the outbox + playlist-diff pipeline. Never fail the create if the
+        // add throws — the playlist already exists in the rootlist.
+        var trackCount = 0;
         if (trackIds is { Count: > 0 })
-            _logger?.LogInformation("CreatePlaylistAsync: {Count} pending trackIds (track-add deferred)", trackIds.Count);
+        {
+            try
+            {
+                await AddTracksToPlaylistCoreAsync(newUri, trackIds, ct);
+                trackCount = trackIds.Count;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "CreatePlaylistAsync: seeding {Count} tracks failed for {Uri}", trackIds.Count, newUri);
+            }
+        }
 
         return new PlaylistSummaryDto
         {
             Id = newUri,
             Name = name,
-            TrackCount = 0,
+            TrackCount = trackCount,
             IsOwner = true
         };
     }
@@ -384,6 +397,14 @@ public sealed class PlaylistMutationService : IPlaylistMutationService, IPlaylis
             },
         };
         await PostAttributeChangeAsync(playlistId, partial, ct);
+
+        // The server's change response may not echo the new picture, which would
+        // leave PreserveSummaryFields holding the OLD cover. Write the cover we
+        // already know (the registered picture id) straight into the cache; its
+        // Updated event refreshes the sidebar row and the open page inline — no
+        // rootlist refetch.
+        var coverUrl = "spotify:image:" + Convert.ToHexString(pictureId).ToLowerInvariant();
+        await _playlistCache.SetPlaylistImageAsync(playlistId, coverUrl, ct);
     }
 
     public async Task RemovePlaylistCoverAsync(string playlistId, CancellationToken ct = default)
@@ -396,6 +417,10 @@ public sealed class PlaylistMutationService : IPlaylistMutationService, IPlaylis
         };
         partial.NoValue.Add(Wavee.Protocol.Playlist.ListAttributeKind.ListPicture);
         await PostAttributeChangeAsync(playlistId, partial, ct);
+
+        // Drop the known cover inline so the sidebar / page revert to the mosaic
+        // (the Updated event drives OnPlaylistContentsChanged's mosaic rebuild).
+        await _playlistCache.SetPlaylistImageAsync(playlistId, null, ct);
     }
 
     /// <summary>

--- a/src/Wavee/Core/Playlists/IPlaylistCacheService.cs
+++ b/src/Wavee/Core/Playlists/IPlaylistCacheService.cs
@@ -49,6 +49,16 @@ public interface IPlaylistCacheService
         Wavee.Protocol.Playlist.SelectedListContent content,
         CancellationToken ct = default);
 
+    /// <summary>
+    /// Patches a playlist's cover image directly from a value the caller already
+    /// knows (e.g. the picture id just registered for an upload) — no server
+    /// round-trip. Updates the hot + persisted cache and fires <see cref="Changes"/>
+    /// (a <see cref="PlaylistChangeKind.Updated"/> event) so the sidebar and any
+    /// open page pick up the new cover inline. No-op if the playlist isn't cached
+    /// or the URL is unchanged. Pass <c>null</c> to clear (revert to mosaic).
+    /// </summary>
+    Task SetPlaylistImageAsync(string playlistUri, string? imageUrl, CancellationToken ct = default);
+
     IObservable<PlaylistChangeEvent> Changes { get; }
 }
 

--- a/src/Wavee/Core/Playlists/PlaylistCacheService.cs
+++ b/src/Wavee/Core/Playlists/PlaylistCacheService.cs
@@ -364,6 +364,31 @@ public sealed class PlaylistCacheService : IPlaylistCacheService, IDisposable
         return merged;
     }
 
+    public async Task SetPlaylistImageAsync(string playlistUri, string? imageUrl, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(playlistUri);
+
+        var existing = _hotCache.Get(playlistUri);
+        if (existing is null)
+        {
+            var persisted = await _database.GetPlaylistCacheEntryAsync(playlistUri, touchAccess: false, ct);
+            if (persisted is not null)
+                existing = DeserializePlaylist(persisted);
+        }
+        if (existing is null) return;                                       // nothing cached to patch
+        if (string.Equals(existing.ImageUrl, imageUrl, StringComparison.Ordinal)) return;
+
+        var merged = existing with { ImageUrl = imageUrl };
+        await PersistPlaylistAsync(merged, ct);
+        _hotCache.Set(playlistUri, merged);
+
+        _changes.OnNext(new PlaylistChangeEvent
+        {
+            Uri = playlistUri,
+            Kind = PlaylistChangeKind.Updated
+        });
+    }
+
     public Task InvalidateAsync(string playlistUri, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(playlistUri);


### PR DESCRIPTION
Fixes four playlist create/edit state bugs (reported from in-app testing), plus a small logging cleanup.

## Bugs fixed

**1. New playlist from a track's "Add to playlist → New playlist" didn't add the track.**
`CreatePlaylistCoreAsync` was logging the selected tracks as "deferred" and never adding them. It now calls the existing `AddTracksToPlaylistCoreAsync` after create and returns the real `TrackCount`.

**2. Cover edits didn't reach the sidebar / open page.** The cache learned the new cover only from `ChangePlaylistAsync`'s response, and `PreserveSummaryFields` (`ImageUrl = fetched.ImageUrl ?? existing.ImageUrl`) kept the **old** image when the response didn't echo the new `Picture`. We already hold the registered picture id, so a new `IPlaylistCacheService.SetPlaylistImageAsync` writes the known cover (`spotify:image:{hex}`) straight into the cache — its `Updated` event is already consumed by the sidebar row (`OnPlaylistContentsChanged`) and the open page. **Inline, no rootlist refetch.** Remove-cover clears it back to the mosaic the same way.

**3. CRITICAL — uploaded cover leaked onto every playlist page.** `ClearCoverPreview()` ran only in the `catch` branch, so a *successful* upload left the unbound `CoverPreviewImage` overlay set on the reused `PlaylistPage` instance, rendering on top of every other playlist's cover (including editorial ones). Now cleared in `finally` and at the start of every `LoadParameter` (covers navigate-mid-upload); made null-safe.

**4. Recommended Songs "+" was inert.** `Command="{Binding ElementName=PageRoot, …}"` doesn't resolve inside the recommendations `ItemsRepeater` item template (separate namescope). Replaced with a code-behind `Click` that executes the command against the page ViewModel; added a guard-skip log.

## Cleanup

Removed the leftover `[odbg]` reorder-overlap debug dump in `TrackDataGrid` (per-frame `Debug.WriteLine` per realized row after every drop, added in #21). Shared `FindDescendant` / `CollectDescendants` helpers are kept — the reorder settle-mask path uses them.

## Testing

Built/tested in-app:
- Add to playlist → New playlist → the originating track lands in the new list.
- Upload a cover to playlist A → A shows it; other playlists keep their own covers; sidebar row updates.
- Remove cover → reverts to mosaic.
- Recommended "+" adds the song (drops from recs, lands in the track list).