### PR TITLE
Misc UI fixes: playlist-add notification, Liked Songs row, Artists size slider, search-flyout thumbnails

### DIFF
--- a/src/Wavee.UI.WinUI/Controls/ContextMenu/Builders/AddToPlaylistSubmenuBuilder.cs
+++ b/src/Wavee.UI.WinUI/Controls/ContextMenu/Builders/AddToPlaylistSubmenuBuilder.cs
@@ -221,13 +221,10 @@ public static class AddToPlaylistSubmenuBuilder
             // /playlist/v2 wire contract). Pass the full list — don't second-
             // guess.
             await mutations.AddTracksToPlaylistAsync(playlistId, uris).ConfigureAwait(true);
-            var noun = uris.Count == 1 ? "track" : "tracks";
-            notifications?.Show(
-                string.IsNullOrEmpty(playlistName)
-                    ? $"Added {uris.Count} {noun} to playlist"
-                    : $"Added {uris.Count} {noun} to {playlistName}",
-                NotificationSeverity.Success,
-                TimeSpan.FromSeconds(3));
+            // No success toast here: the undoable add already records a rich Activity
+            // entry (with the playlist name + Undo) via the action runner. Showing a
+            // toast too produced a duplicate, name-less "Added N tracks to playlist"
+            // entry in the Activity feed.
         }
         catch
         {

--- a/src/Wavee.UI.WinUI/Controls/Omnibar/SearchFlyoutPanel.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Omnibar/SearchFlyoutPanel.xaml.cs
@@ -297,6 +297,16 @@ public sealed partial class SearchFlyoutPanel : UserControl
     {
         if (sender is not FrameworkElement root)
             return;
+
+        // The entity thumbnail is a CompositionImage inside a Popup + ItemsRepeater;
+        // its own cold load can kick before the popup's visual is attached and bail
+        // (TryLoad:bail:notAttached), leaving the image blank with nothing to re-fire
+        // it. The row's Loaded confirms the subtree is in the live tree, so re-kick the
+        // load here (dispatched so the image's own attach has settled). Runs on every
+        // realization, and forceReapply also re-paints a retained-but-unpainted surface.
+        if (FindCompositionImage(root) is { } image)
+            root.DispatcherQueue?.TryEnqueue(image.RefreshCurrentImage);
+
         if (root.GetValue(EntityDragAttachedProperty) is true)
             return;
 
@@ -304,6 +314,20 @@ public sealed partial class SearchFlyoutPanel : UserControl
         ManualDragAttachment.AttachWithPackageWriter(
             root,
             () => SearchSuggestionInteraction.BuildDragPayload(root.DataContext as SearchSuggestionItem));
+    }
+
+    private static Wavee.UI.WinUI.Controls.Imaging.CompositionImage? FindCompositionImage(DependencyObject root)
+    {
+        var count = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < count; i++)
+        {
+            var child = VisualTreeHelper.GetChild(root, i);
+            if (child is Wavee.UI.WinUI.Controls.Imaging.CompositionImage img)
+                return img;
+            if (FindCompositionImage(child) is { } nested)
+                return nested;
+        }
+        return null;
     }
 
     private void EntityRoot_RightTapped(object sender, RightTappedRoutedEventArgs e)

--- a/src/Wavee.UI.WinUI/Data/Contexts/ActivityService.cs
+++ b/src/Wavee.UI.WinUI/Data/Contexts/ActivityService.cs
@@ -611,7 +611,15 @@ public sealed partial class ActivityService : ObservableObject, IActivityService
             .Where(static value => !string.IsNullOrWhiteSpace(value))
             .ToArray();
 
-        var playlistName = DisplayName(playlist, playlistUri);
+        // Owned playlists live in spotify_playlists, not the entities table, so the
+        // entity lookup above misses and DisplayName would fall back to the bare id.
+        // Resolve the real name from the playlist cache when the entity has no title.
+        var playlistName = FirstNonWhiteSpace(
+            playlist?.Title,
+            await TryGetPlaylistNameAsync(playlistUri, ct).ConfigureAwait(false),
+            ShortUri(playlistUri),
+            playlistUri,
+            "playlist")!;
         var action = added ? "Added" : "Removed";
         var noun = count == 1 ? "song" : "songs";
         var title = $"{action} {count} {noun} to \"{playlistName}\"";
@@ -708,6 +716,25 @@ public sealed partial class ActivityService : ObservableObject, IActivityService
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger?.LogDebug(ex, "Failed to load activity entity metadata for {Uri}", uri);
+            return null;
+        }
+    }
+
+    // Playlist names live in spotify_playlists (the playlist cache), not the
+    // entities table — used to resolve a real name for playlist activity entries.
+    private async Task<string?> TryGetPlaylistNameAsync(string? uri, CancellationToken ct)
+    {
+        if (_database is null || string.IsNullOrWhiteSpace(uri))
+            return null;
+
+        try
+        {
+            var entry = await _database.GetPlaylistCacheEntryAsync(uri, false, ct).ConfigureAwait(false);
+            return string.IsNullOrWhiteSpace(entry?.Name) ? null : entry!.Name;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger?.LogDebug(ex, "Failed to resolve playlist name for activity {Uri}", uri);
             return null;
         }
     }

--- a/src/Wavee.UI.WinUI/Strings/en-US/Resources.resw
+++ b/src/Wavee.UI.WinUI/Strings/en-US/Resources.resw
@@ -5154,7 +5154,7 @@ Supports Markdown: **bold**, _italic_, `code`, - lists</value>
     <value>Thank you! Your feedback has been received.</value>
   </data>
   <data name="Views_LikedSongsView__Auto_600.Text" xml:space="preserve">
-    <value> &amp;#x2022; </value>
+    <value> &#x2022; </value>
   </data>
   <data name="Views_LikedSongsView__Auto_601.ToolTipService.ToolTip" xml:space="preserve">
     <value>Show only tracks with music videos</value>

--- a/src/Wavee.UI.WinUI/Views/ArtistsLibraryView.xaml
+++ b/src/Wavee.UI.WinUI/Views/ArtistsLibraryView.xaml
@@ -335,7 +335,9 @@
                         AllowedSortKeys="Recents,RecentlyAdded,Alphabetical"
                         SortBy="{x:Bind ViewModel.SortBy, Mode=TwoWay}"
                         SortDirection="{x:Bind ViewModel.SortDirection, Mode=TwoWay}"
-                        ViewMode="{x:Bind ViewModel.ViewMode, Mode=TwoWay}"/>
+                        ViewMode="{x:Bind ViewModel.ViewMode, Mode=TwoWay}"
+                        GridScale="{x:Bind ViewModel.GridScale, Mode=TwoWay}"
+                        ShowGridScale="True"/>
 
                     <TextBox x:Uid="Views_ArtistsLibraryView__TextBox_1"
                         Grid.Column="1"

--- a/src/Wavee.UI.WinUI/Views/ArtistsLibraryView.xaml.cs
+++ b/src/Wavee.UI.WinUI/Views/ArtistsLibraryView.xaml.cs
@@ -83,7 +83,8 @@ public sealed partial class ArtistsLibraryView : UserControl, IDisposable, IInPa
         {
             UpdateTracksPanelVisibility(ViewModel.IsTracksPanelVisible, animate: true);
         }
-        else if (e.PropertyName == nameof(ViewModel.ViewMode))
+        else if (e.PropertyName == nameof(ViewModel.ViewMode)
+                 || e.PropertyName == nameof(ViewModel.GridScale))
         {
             ApplyArtistsViewMode();
         }
@@ -122,16 +123,18 @@ public sealed partial class ArtistsLibraryView : UserControl, IDisposable, IInPa
 
             case LibraryViewMode.CompactGrid:
                 // Compact card shows the name only (~1 line) under the avatar.
-                ApplyArtistGridLayout(minItemWidth: 104, spacing: 8, textBandHeight: 34);
+                ApplyArtistGridLayout(minItemWidth: 104, spacing: 8, savedTextBand: 34, likedTextBand: 34);
                 ApplyTemplateFromResources("ArtistCompactGridItemTemplate");
                 ApplyLikedTemplateFromResources("LikedArtistCompactGridItemTemplate");
                 break;
 
             case LibraryViewMode.DefaultGrid:
-                // CSS auto-fill + 1fr: circular avatars grow with the column width; row
-                // height = avatar (square) + a fixed text band sized for the
-                // From-Liked-Songs card's 3 lines. No clip, no empty space at any width.
-                ApplyArtistGridLayout(minItemWidth: 150, spacing: 12, textBandHeight: 88);
+                // Circular avatars grow with the column width; row height = avatar (square)
+                // + a text band. The Saved card shows name + recents (~2 lines); the
+                // From-Liked card adds a liked-songs count (~3 lines), so it gets a taller
+                // band. Reserving the From-Liked height for Saved too was floating the Saved
+                // cards' text with too much vertical space.
+                ApplyArtistGridLayout(minItemWidth: 150, spacing: 12, savedTextBand: 56, likedTextBand: 88);
                 ApplyTemplateFromResources("ArtistDefaultGridItemTemplate");
                 ApplyLikedTemplateFromResources("LikedArtistDefaultGridItemTemplate");
                 break;
@@ -145,25 +148,30 @@ public sealed partial class ArtistsLibraryView : UserControl, IDisposable, IInPa
         }
     }
 
-    private void ApplyArtistGridLayout(double minItemWidth, double spacing, double textBandHeight)
+    private void ApplyArtistGridLayout(double minItemWidth, double spacing, double savedTextBand, double likedTextBand)
     {
+        // Match the album grid's size slider: scale the avatar (item width) and its text
+        // band by GridScale; spacing stays fixed. GridScale defaults to 1.0.
+        var scale = ViewModel.GridScale <= 0 ? 1.0 : ViewModel.GridScale;
+        var scaledWidth = minItemWidth * scale;
+
         if (ArtistsView is not null)
         {
             _savedGridLayout ??= new ResponsiveGridLayout { AspectRatio = 1.0 };
-            _savedGridLayout.MinItemWidth = minItemWidth;
+            _savedGridLayout.MinItemWidth = scaledWidth;
             _savedGridLayout.ColumnSpacing = spacing;
             _savedGridLayout.RowSpacing = spacing;
-            _savedGridLayout.TextBandHeight = textBandHeight;
+            _savedGridLayout.TextBandHeight = savedTextBand * scale;
             if (!ReferenceEquals(ArtistsView.Layout, _savedGridLayout))
                 ArtistsView.Layout = _savedGridLayout;
         }
         if (LikedArtistsView is not null)
         {
             _likedGridLayout ??= new ResponsiveGridLayout { AspectRatio = 1.0 };
-            _likedGridLayout.MinItemWidth = minItemWidth;
+            _likedGridLayout.MinItemWidth = scaledWidth;
             _likedGridLayout.ColumnSpacing = spacing;
             _likedGridLayout.RowSpacing = spacing;
-            _likedGridLayout.TextBandHeight = textBandHeight;
+            _likedGridLayout.TextBandHeight = likedTextBand * scale;
             if (!ReferenceEquals(LikedArtistsView.Layout, _likedGridLayout))
                 LikedArtistsView.Layout = _likedGridLayout;
         }

--- a/src/Wavee.UI.WinUI/Views/LikedSongsView.xaml
+++ b/src/Wavee.UI.WinUI/Views/LikedSongsView.xaml
@@ -34,7 +34,7 @@
             IsTagsLoading picks between the real TokenView and the shimmer placeholders.
         -->
         <Grid Grid.Row="0"
-              Padding="16,12,16,4"
+              Padding="8,12,8,4"
               Visibility="{x:Bind ViewModel.HasFilterChipsOrShimmer, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
             <toolkit:TokenView
                 x:Name="FilterTokenView"


### PR DESCRIPTION
Three small, independent UI/data fixes (reported from in-app testing), one commit each.

## Activity: playlist-add notification (`504253c`)
- **Duplicate entries** — `AddToPlaylistSubmenuBuilder` showed a success toast (auto-posted to the Activity feed) on top of the rich entry the undoable add already records. Dropped the toast; the rich entry (name + Undo) is the single record. Error/empty toasts kept.
- **Playlist id instead of name** — `ActivityService` resolved the name via the `entities` table, but owned playlists live in `spotify_playlists`. Added a `GetPlaylistCacheEntryAsync` name lookup to the resolution chain.

## Liked Songs (`63cc0d7`)
- **Separator showed `&#x2022;` literally** — the en-US resource was double-escaped (`&amp;#x2022;`); now `&#x2022;` → `•` (matches ko-KR's `·`).
- **Filter-pill row misaligned** — used `Padding=16` while the Play/stats toolbar uses `8`, so "All" didn't line up with "Play". Matched to `Padding="8,12,8,4"`.

## Artists library (`2a28a5a`)
- **Missing card-size slider** — added `GridScale`/`ShowGridScale` to the Artists toolbar panel (VM property already existed) and made the code-behind grid layout scale by `GridScale`, like Albums.
- **Wrong vertical spacing** — the `88px` text band sized for the 3-line *From-Liked* card was applied to the 2-line *Saved* cards, floating their text. Saved now gets its own `56px` band.

## Testing
Built/tested in-app: add a track to a playlist → one Activity entry with the real name; Liked Songs shows `146 songs • 8 hr 47 min` and the pills align with Play; Artists has a working size slider and tighter Saved cards.