### PR TITLE
Search top-result card: fix light-mode hover white-out + stagger results

### DIFF
--- a/src/Wavee.UI.WinUI/Controls/Search/SearchResultHeroCard.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Search/SearchResultHeroCard.xaml.cs
@@ -130,12 +130,18 @@ public sealed partial class SearchResultHeroCard : UserControl
 
     private void ApplyHoverBackground()
     {
-        var key = _isPressed
-            ? "CardBackgroundFillColorTertiaryBrush"
-            : _isHovered
-            ? "CardBackgroundFillColorTertiaryBrush"
-            : "CardBackgroundFillColorSecondaryBrush";
-        RootBorder.Background = (Brush)Application.Current.Resources[key];
+        // When a hero image / palette wash is showing through the otherwise-
+        // transparent chrome, NEVER paint an opaque hover/rest fill over it: the
+        // RootBorder sits ABOVE the bleed layer, so an opaque CardBackground brush
+        // covered the artist photo and whited the card out in light mode. Those
+        // cards take their hover feedback from the border + play-button scale.
+        var hasHeroVisual = HeroInkOverlay.Visibility == Visibility.Visible;
+        RootBorder.Background = hasHeroVisual
+            ? new SolidColorBrush(Windows.UI.Color.FromArgb(0, 0, 0, 0))
+            : (Brush)Application.Current.Resources[
+                _isPressed || _isHovered
+                    ? "CardBackgroundFillColorTertiaryBrush"
+                    : "CardBackgroundFillColorSecondaryBrush"];
         RootBorder.BorderBrush = (Brush)Application.Current.Resources[_isHovered || _isPressed
             ? "ControlStrokeColorDefaultBrush"
             : "CardStrokeColorDefaultBrush"];
@@ -283,6 +289,9 @@ public sealed partial class SearchResultHeroCard : UserControl
         HeroInkOverlay.Visibility = hasVisual ? Visibility.Visible : Visibility.Collapsed;
 
         ApplyPaletteBrush();
+        // The hero visual just resolved — re-evaluate the chrome fill so a hover
+        // that started before the image loaded stops covering it (and vice versa).
+        ApplyHoverBackground();
     }
 
     private void DisposeArtistSubscription()

--- a/src/Wavee.UI.WinUI/Views/SearchPage.xaml
+++ b/src/Wavee.UI.WinUI/Views/SearchPage.xaml
@@ -16,6 +16,7 @@
     xmlns:home="using:Wavee.UI.WinUI.ViewModels.Home"
     xmlns:homeViews="using:Wavee.UI.WinUI.Views.Home"
     xmlns:browseControls="using:Wavee.UI.WinUI.Controls.Browse"
+    xmlns:anim="using:Wavee.UI.WinUI.Controls.Behaviors"
     mc:Ignorable="d"
     Background="Transparent"
     waveeHelpers:PageEntranceFade.Fade="True">
@@ -166,7 +167,7 @@
             <StackPanel Spacing="10"
                         Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay, Converter={StaticResource InverseBoolToVisibilityConverter}}">
                 <search:SearchResultHeroCard x:Name="TopResultCard"
-                                            
+                                             anim:StaggeredEntrance.IsEntranceAnimated="True"
                                              Margin="0,0,0,10"
                                              Item="{x:Bind ViewModel.TopResult, Mode=OneWay}"
                                              CardRightTapped="TopResult_RightTapped"
@@ -201,6 +202,7 @@
                                     <ItemsRepeater.ItemTemplate>
                                         <DataTemplate x:DataType="pathfinder:SearchResultItem">
                                             <cards:ContentCard
+                                                anim:StaggeredEntrance.IsEntranceAnimated="True"
                                                 ImageUrl="{x:Bind ImageUrl}"
                                                 Title="{x:Bind Name}"
                                                 Subtitle="{x:Bind DisplaySubtitle}"
@@ -225,6 +227,7 @@
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate x:DataType="pathfinder:SearchResultItem">
                             <search:SearchResultRowCard Item="{x:Bind}"
+                                                        anim:StaggeredEntrance.IsEntranceAnimated="True"
                                                         CardRightTapped="ResultRow_RightTapped"
                                                         Tapped="ResultRow_Tapped"/>
                         </DataTemplate>


### PR DESCRIPTION
Top search result hero card.

- **Light-mode hover white-out:** `ApplyHoverBackground` painted an opaque `CardBackgroundFillColorTertiaryBrush` onto `RootBorder`, which sits *above* the bleed-image layer — so on hover it covered the artist photo (near-white in light mode). Now kept transparent when a hero image/palette is showing; hover feedback stays the border highlight + play-button scale. Plain cards keep their normal subtle hover.
- **Stagger:** added `StaggeredEntrance` to the hero, result rows, and section cards so results cascade in.