### PR TITLE
Details tab: load on first open instead of after a tab round-trip

### DIFF
--- a/src/Wavee.UI.WinUI/Controls/RightPanel/Details/DetailsTabHost.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/RightPanel/Details/DetailsTabHost.xaml.cs
@@ -422,6 +422,16 @@ public sealed partial class DetailsTabHost : UserControl
         UpdateDetailsSnippetTimerState();
         UpdatePodcastChapterTimelineTimerState();
         UpdateDetailsLyricsUpdateMode();
+
+        // First-open fix: the parent flips IsDetailsTabActive BEFORE IsPanelVisible,
+        // so HandleTabActivationChanged saw IsPanelVisible=false and skipped the
+        // initial LoadAndBindDetailsAsync. Kick it here once visibility flips true
+        // while the tab is active so the first Details open (or a panel reopen with
+        // Details already selected) populates without needing a tab round-trip.
+        // No double-load: whichever of the two DPs settles first is gated out by its
+        // own (other-DP-still-false) check.
+        if (IsDetailsTabActive && IsPanelVisible && _detailsVm != null)
+            _ = LoadAndBindDetailsAsync();
     }
 
     private void ApplyEmbeddedChromeMask()


### PR DESCRIPTION
Opening the **Details** tab as the first right-panel tab showed only the output-device card; the artist canvas / bio / etc. appeared only after switching to another tab and back.

Root cause: in `RightPanelView.UpdateContentVisibility` the parent flips `IsDetailsTabActive` **before** `IsPanelVisible`, so `HandleTabActivationChanged` saw `IsPanelVisible=false` and skipped its initial `LoadAndBindDetailsAsync`; `HandlePanelVisibilityChanged` then did not kick the load.

Fix: `HandlePanelVisibilityChanged` now also kicks the load when the tab is active + visible — so whichever of the two DPs settles last triggers it. No double-load (the first to settle is gated out by the other still being false). Also covers reopening the panel with Details already selected.