### PR TITLE
Reusable zoomable cover viewer (Save as…), wired on album + show covers

### DIFF
--- a/src/Wavee.UI.WinUI/Controls/Common/ImageZoomDialog.xaml
+++ b/src/Wavee.UI.WinUI/Controls/Common/ImageZoomDialog.xaml
@@ -1,21 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ContentDialog
+<UserControl
     x:Class="Wavee.UI.WinUI.Controls.Common.ImageZoomDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    PrimaryButtonText="Save as…"
-    CloseButtonText="Close"
-    DefaultButton="Close"
-    CornerRadius="12">
+    mc:Ignorable="d">
 
-    <!-- Generic, reusable cover/image viewer. Width/Height of Viewer is set in
-         ShowAsync from the window size so the dialog scales with the app. The
-         ScrollViewer provides zoom (scroll / pinch) + pan; double-click resets. -->
-    <Grid x:Name="Viewer" Width="520" Height="520">
+    <!-- Full-window lightbox: the image IS the content (stretched edge-to-edge),
+         no title / button bar; close + save float over the image. Sized to the
+         window in code (ShowAsync). Tapping the dimmed frame, the X, or Esc closes. -->
+    <Grid x:Name="OverlayRoot"
+          Background="#E6000000"
+          IsTabStop="True"
+          Tapped="OverlayRoot_Tapped"
+          KeyDown="OverlayRoot_KeyDown">
+
+        <!-- Zoom / pan surface. ImageHost is sized to the viewport in code so the
+             Uniform image fits at zoom factor 1 and stays centred; zoom scales it. -->
         <ScrollView x:Name="ZoomScroller"
+                    Margin="24"
+                    Background="Transparent"
                     ZoomMode="Enabled"
                     MinZoomFactor="1"
                     MaxZoomFactor="8"
@@ -24,24 +29,55 @@
                     VerticalScrollMode="Auto"
                     HorizontalScrollBarVisibility="Hidden"
                     VerticalScrollBarVisibility="Hidden"
-                    CornerRadius="8"
-                    Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
-                    DoubleTapped="ZoomScroller_DoubleTapped">
-            <Image x:Name="FullImage"
-                   Stretch="Uniform"
-                   HorizontalAlignment="Center"
-                   VerticalAlignment="Center"/>
+                    DoubleTapped="ZoomScroller_DoubleTapped"
+                    SizeChanged="ZoomScroller_SizeChanged">
+            <Grid x:Name="ImageHost">
+                <Image x:Name="FullImage"
+                       Stretch="Uniform"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"/>
+            </Grid>
         </ScrollView>
 
+        <!-- Floating controls over the image (top-right). -->
+        <StackPanel Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    Spacing="8"
+                    Margin="0,16,16,0">
+            <Button x:Name="SaveButton"
+                    Width="40" Height="40" Padding="0" CornerRadius="20"
+                    Background="#99000000" BorderThickness="0"
+                    Click="Save_Click"
+                    ToolTipService.ToolTip="Save as…">
+                <FontIcon Glyph="&#xE74E;"
+                          FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                          FontSize="16"
+                          Foreground="White"/>
+            </Button>
+            <Button x:Name="CloseButton"
+                    Width="40" Height="40" Padding="0" CornerRadius="20"
+                    Background="#99000000" BorderThickness="0"
+                    Click="Close_Click"
+                    ToolTipService.ToolTip="Close">
+                <FontIcon Glyph="&#xE8BB;"
+                          FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                          FontSize="15"
+                          Foreground="White"/>
+            </Button>
+        </StackPanel>
+
+        <!-- Zoom hint -->
         <Border VerticalAlignment="Bottom"
                 HorizontalAlignment="Center"
-                Margin="0,0,0,10"
+                Margin="0,0,0,16"
                 Background="#99000000"
                 CornerRadius="14"
-                Padding="12,5">
+                Padding="12,5"
+                IsHitTestVisible="False">
             <TextBlock Text="Scroll to zoom · drag to pan · double-click to reset"
                        FontSize="11"
                        Foreground="White"/>
         </Border>
     </Grid>
-</ContentDialog>
+</UserControl>

--- a/src/Wavee.UI.WinUI/Controls/Common/ImageZoomDialog.xaml
+++ b/src/Wavee.UI.WinUI/Controls/Common/ImageZoomDialog.xaml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ContentDialog
+    x:Class="Wavee.UI.WinUI.Controls.Common.ImageZoomDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    PrimaryButtonText="Save as…"
+    CloseButtonText="Close"
+    DefaultButton="Close"
+    CornerRadius="12">
+
+    <!-- Generic, reusable cover/image viewer. Width/Height of Viewer is set in
+         ShowAsync from the window size so the dialog scales with the app. The
+         ScrollViewer provides zoom (scroll / pinch) + pan; double-click resets. -->
+    <Grid x:Name="Viewer" Width="520" Height="520">
+        <ScrollView x:Name="ZoomScroller"
+                    ZoomMode="Enabled"
+                    MinZoomFactor="1"
+                    MaxZoomFactor="8"
+                    ContentOrientation="Both"
+                    HorizontalScrollMode="Auto"
+                    VerticalScrollMode="Auto"
+                    HorizontalScrollBarVisibility="Hidden"
+                    VerticalScrollBarVisibility="Hidden"
+                    CornerRadius="8"
+                    Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                    DoubleTapped="ZoomScroller_DoubleTapped">
+            <Image x:Name="FullImage"
+                   Stretch="Uniform"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"/>
+        </ScrollView>
+
+        <Border VerticalAlignment="Bottom"
+                HorizontalAlignment="Center"
+                Margin="0,0,0,10"
+                Background="#99000000"
+                CornerRadius="14"
+                Padding="12,5">
+            <TextBlock Text="Scroll to zoom · drag to pan · double-click to reset"
+                       FontSize="11"
+                       Foreground="White"/>
+        </Border>
+    </Grid>
+</ContentDialog>

--- a/src/Wavee.UI.WinUI/Controls/Common/ImageZoomDialog.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Common/ImageZoomDialog.xaml.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Wavee.UI.Helpers;
@@ -20,85 +21,120 @@ using Windows.Storage.Streams;
 namespace Wavee.UI.WinUI.Controls.Common;
 
 /// <summary>
-/// Reusable full-cover viewer: shows an image in a zoom/pan-able overlay dialog
-/// with an "export (Save as…)" action. Used by any cover surface — albums,
-/// playlists, podcasts/shows, etc. — via <see cref="ShowAsync"/>.
+/// Reusable full-window cover/image lightbox: the image is the content (stretched
+/// edge-to-edge, zoom + pan), with floating close + "Save as…" controls over it —
+/// no dialog chrome. Used by any cover surface (albums, shows/podcasts, etc.) via
+/// <see cref="ShowAsync"/>. Hosted in a <see cref="Popup"/>.
 /// </summary>
-public sealed partial class ImageZoomDialog : ContentDialog
+public sealed partial class ImageZoomDialog : UserControl
 {
     private string? _imageUrl;
     private string _suggestedFileName = "cover";
+    private Popup? _popup;
+    private XamlRoot? _xamlRoot;
+    private TaskCompletionSource<bool>? _closedTcs;
 
     public ImageZoomDialog()
     {
         InitializeComponent();
-        PrimaryButtonClick += OnSavePrimaryClick;
     }
 
     /// <summary>
-    /// Opens the viewer for <paramref name="imageUrl"/> (a Spotify image URI or a
-    /// plain https URL). <paramref name="title"/> is shown in the dialog header and
-    /// <paramref name="suggestedFileName"/> seeds the Save dialog (e.g. the album /
-    /// playlist / show name). No-ops when the image URL can't be resolved.
+    /// Opens the lightbox for <paramref name="imageUrl"/> (a Spotify image URI or a
+    /// plain https URL). <paramref name="suggestedFileName"/> seeds the Save dialog
+    /// (e.g. the album / show name). <paramref name="title"/> is accepted for API
+    /// stability but not shown (the lightbox has no header). Returns a task that
+    /// completes when the viewer is dismissed. No-ops when the URL can't be resolved.
     /// </summary>
-    public static async Task ShowAsync(XamlRoot? xamlRoot, string? imageUrl, string? title, string? suggestedFileName)
+    public static Task ShowAsync(XamlRoot? xamlRoot, string? imageUrl, string? title, string? suggestedFileName)
     {
-        if (xamlRoot is null) return;
+        if (xamlRoot is null) return Task.CompletedTask;
         var httpsUrl = SpotifyImageHelper.ToHttpsUrl(imageUrl);
-        if (string.IsNullOrEmpty(httpsUrl)) return;
+        if (string.IsNullOrEmpty(httpsUrl)) return Task.CompletedTask;
 
-        var dialog = new ImageZoomDialog
+        var overlay = new ImageZoomDialog
         {
-            XamlRoot = xamlRoot,
-            Title = string.IsNullOrWhiteSpace(title) ? "Cover art" : title,
             _imageUrl = httpsUrl,
             _suggestedFileName = SanitizeFileName(suggestedFileName),
+            _xamlRoot = xamlRoot,
         };
-        // Match the dialog chrome (background / title / buttons) to the app's
-        // current light/dark theme — robust even when the app applies a
-        // per-element RequestedTheme override rather than an app-wide one.
+        // Match tooltip / focus chrome to the app theme (the surface itself is
+        // intentionally dark, like any image viewer).
         if (xamlRoot.Content is FrameworkElement rootElement)
-            dialog.RequestedTheme = rootElement.ActualTheme;
+            overlay.RequestedTheme = rootElement.ActualTheme;
         // Full-resolution decode (no DecodePixelSize cap) so zoom reveals detail.
-        dialog.FullImage.Source = new BitmapImage(new Uri(httpsUrl));
+        overlay.FullImage.Source = new BitmapImage(new Uri(httpsUrl));
 
-        // Scale the square viewer to the window so it "expands" responsively.
-        var size = xamlRoot.Size;
-        var side = Math.Clamp(Math.Min(size.Width, size.Height) * 0.78, 320, 760);
-        dialog.Viewer.Width = side;
-        dialog.Viewer.Height = side;
-        // Size the image to the viewport so it FITS at zoom factor 1 (a ScrollViewer
-        // otherwise measures an unconstrained Uniform image at its natural pixels);
-        // zoom then scales beyond fit. Uniform letterboxes non-square art cleanly.
-        dialog.FullImage.Width = side;
-        dialog.FullImage.Height = side;
+        var popup = new Popup
+        {
+            XamlRoot = xamlRoot,
+            Child = overlay,
+        };
+        overlay._popup = popup;
+        overlay.SizeToWindow();
+        xamlRoot.Changed += overlay.OnXamlRootChanged;
 
-        await dialog.ShowAsync();
+        var tcs = new TaskCompletionSource<bool>();
+        overlay._closedTcs = tcs;
+        popup.IsOpen = true;
+        overlay.OverlayRoot.Focus(FocusState.Programmatic);
+        return tcs.Task;
+    }
+
+    private void SizeToWindow()
+    {
+        if (_xamlRoot is null) return;
+        Width = _xamlRoot.Size.Width;
+        Height = _xamlRoot.Size.Height;
+    }
+
+    private void OnXamlRootChanged(XamlRoot sender, XamlRootChangedEventArgs args) => SizeToWindow();
+
+    private void Close()
+    {
+        if (_xamlRoot is not null)
+            _xamlRoot.Changed -= OnXamlRootChanged;
+        if (_popup is not null)
+            _popup.IsOpen = false;
+        _closedTcs?.TrySetResult(true);
+    }
+
+    private void Close_Click(object sender, RoutedEventArgs e) => Close();
+
+    private void OverlayRoot_Tapped(object sender, TappedRoutedEventArgs e)
+    {
+        // Only the dimmed frame around the image dismisses — taps on the image
+        // (or the floating buttons) bubble with a different OriginalSource.
+        if (ReferenceEquals(e.OriginalSource, OverlayRoot))
+            Close();
+    }
+
+    private void OverlayRoot_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key == Windows.System.VirtualKey.Escape)
+        {
+            Close();
+            e.Handled = true;
+        }
+    }
+
+    private void ZoomScroller_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        // Keep the zoom content the size of the viewport so the Uniform image fits
+        // at zoom factor 1 (a ScrollView otherwise measures it at natural pixels)
+        // and stays centred; zoom then scales beyond fit.
+        ImageHost.Width = ZoomScroller.ActualWidth;
+        ImageHost.Height = ZoomScroller.ActualHeight;
     }
 
     private void ZoomScroller_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
     {
-        // ScrollView zooms programmatically via ZoomTo (no ChangeView). Null
-        // centerPoint zooms about the viewport centre.
         var target = ZoomScroller.ZoomFactor > 1.05f ? 1f : 2.5f;
         ZoomScroller.ZoomTo(target, null);
         e.Handled = true;
     }
 
-    private async void OnSavePrimaryClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
-    {
-        // Keep the viewer open after exporting so the user can keep browsing the art.
-        var deferral = args.GetDeferral();
-        args.Cancel = true;
-        try
-        {
-            await SaveImageAsync();
-        }
-        finally
-        {
-            deferral.Complete();
-        }
-    }
+    private async void Save_Click(object sender, RoutedEventArgs e) => await SaveImageAsync();
 
     private async Task SaveImageAsync()
     {

--- a/src/Wavee.UI.WinUI/Controls/Common/ImageZoomDialog.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Common/ImageZoomDialog.xaml.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Wavee.UI.Helpers;
+using Wavee.UI.WinUI.Data.Models;
+using Wavee.UI.WinUI.Services;
+using Windows.Graphics.Imaging;
+using Windows.Storage;
+using Windows.Storage.Pickers;
+using Windows.Storage.Streams;
+
+namespace Wavee.UI.WinUI.Controls.Common;
+
+/// <summary>
+/// Reusable full-cover viewer: shows an image in a zoom/pan-able overlay dialog
+/// with an "export (Save as…)" action. Used by any cover surface — albums,
+/// playlists, podcasts/shows, etc. — via <see cref="ShowAsync"/>.
+/// </summary>
+public sealed partial class ImageZoomDialog : ContentDialog
+{
+    private string? _imageUrl;
+    private string _suggestedFileName = "cover";
+
+    public ImageZoomDialog()
+    {
+        InitializeComponent();
+        PrimaryButtonClick += OnSavePrimaryClick;
+    }
+
+    /// <summary>
+    /// Opens the viewer for <paramref name="imageUrl"/> (a Spotify image URI or a
+    /// plain https URL). <paramref name="title"/> is shown in the dialog header and
+    /// <paramref name="suggestedFileName"/> seeds the Save dialog (e.g. the album /
+    /// playlist / show name). No-ops when the image URL can't be resolved.
+    /// </summary>
+    public static async Task ShowAsync(XamlRoot? xamlRoot, string? imageUrl, string? title, string? suggestedFileName)
+    {
+        if (xamlRoot is null) return;
+        var httpsUrl = SpotifyImageHelper.ToHttpsUrl(imageUrl);
+        if (string.IsNullOrEmpty(httpsUrl)) return;
+
+        var dialog = new ImageZoomDialog
+        {
+            XamlRoot = xamlRoot,
+            Title = string.IsNullOrWhiteSpace(title) ? "Cover art" : title,
+            _imageUrl = httpsUrl,
+            _suggestedFileName = SanitizeFileName(suggestedFileName),
+        };
+        // Match the dialog chrome (background / title / buttons) to the app's
+        // current light/dark theme — robust even when the app applies a
+        // per-element RequestedTheme override rather than an app-wide one.
+        if (xamlRoot.Content is FrameworkElement rootElement)
+            dialog.RequestedTheme = rootElement.ActualTheme;
+        // Full-resolution decode (no DecodePixelSize cap) so zoom reveals detail.
+        dialog.FullImage.Source = new BitmapImage(new Uri(httpsUrl));
+
+        // Scale the square viewer to the window so it "expands" responsively.
+        var size = xamlRoot.Size;
+        var side = Math.Clamp(Math.Min(size.Width, size.Height) * 0.78, 320, 760);
+        dialog.Viewer.Width = side;
+        dialog.Viewer.Height = side;
+        // Size the image to the viewport so it FITS at zoom factor 1 (a ScrollViewer
+        // otherwise measures an unconstrained Uniform image at its natural pixels);
+        // zoom then scales beyond fit. Uniform letterboxes non-square art cleanly.
+        dialog.FullImage.Width = side;
+        dialog.FullImage.Height = side;
+
+        await dialog.ShowAsync();
+    }
+
+    private void ZoomScroller_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
+    {
+        // ScrollView zooms programmatically via ZoomTo (no ChangeView). Null
+        // centerPoint zooms about the viewport centre.
+        var target = ZoomScroller.ZoomFactor > 1.05f ? 1f : 2.5f;
+        ZoomScroller.ZoomTo(target, null);
+        e.Handled = true;
+    }
+
+    private async void OnSavePrimaryClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    {
+        // Keep the viewer open after exporting so the user can keep browsing the art.
+        var deferral = args.GetDeferral();
+        args.Cancel = true;
+        try
+        {
+            await SaveImageAsync();
+        }
+        finally
+        {
+            deferral.Complete();
+        }
+    }
+
+    private async Task SaveImageAsync()
+    {
+        if (string.IsNullOrEmpty(_imageUrl)) return;
+
+        var notifications = Ioc.Default.GetService<INotificationService>();
+        try
+        {
+            var picker = new FileSavePicker
+            {
+                SuggestedStartLocation = PickerLocationId.PicturesLibrary,
+                SuggestedFileName = _suggestedFileName,
+            };
+            picker.FileTypeChoices.Add("JPEG image", new List<string> { ".jpg" });
+            picker.FileTypeChoices.Add("PNG image", new List<string> { ".png" });
+            WinRT.Interop.InitializeWithWindow.Initialize(picker, global::Wavee.UI.WinUI.MainWindow.Instance.WindowHandle);
+
+            var file = await picker.PickSaveFileAsync();
+            if (file is null) return;
+
+            var http = Ioc.Default.GetService<IHttpClientFactory>()?.CreateClient() ?? new HttpClient();
+            var bytes = await http.GetByteArrayAsync(_imageUrl);
+
+            var isJpeg = file.FileType.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
+                      || file.FileType.Equals(".jpeg", StringComparison.OrdinalIgnoreCase);
+            if (isJpeg)
+            {
+                // Spotify cover art is already JPEG — write through without re-compressing.
+                await FileIO.WriteBytesAsync(file, bytes);
+            }
+            else
+            {
+                await ReencodeAsync(bytes, file, BitmapEncoder.PngEncoderId);
+            }
+
+            notifications?.Show($"Saved to {file.Name}", NotificationSeverity.Success, TimeSpan.FromSeconds(3));
+        }
+        catch (Exception ex)
+        {
+            notifications?.Show($"Couldn't save image: {ex.Message}", NotificationSeverity.Error, TimeSpan.FromSeconds(5));
+        }
+    }
+
+    private static async Task ReencodeAsync(byte[] sourceBytes, StorageFile file, Guid encoderId)
+    {
+        using var inStream = new InMemoryRandomAccessStream();
+        await inStream.WriteAsync(sourceBytes.AsBuffer());
+        inStream.Seek(0);
+
+        var decoder = await BitmapDecoder.CreateAsync(inStream);
+        var pixels = await decoder.GetPixelDataAsync(
+            BitmapPixelFormat.Bgra8,
+            BitmapAlphaMode.Premultiplied,
+            new BitmapTransform(),
+            ExifOrientationMode.RespectExifOrientation,
+            ColorManagementMode.DoNotColorManage);
+
+        using var outStream = await file.OpenAsync(FileAccessMode.ReadWrite);
+        outStream.Size = 0;
+        var encoder = await BitmapEncoder.CreateAsync(encoderId, outStream);
+        encoder.SetPixelData(
+            BitmapPixelFormat.Bgra8,
+            BitmapAlphaMode.Premultiplied,
+            decoder.PixelWidth,
+            decoder.PixelHeight,
+            decoder.DpiX,
+            decoder.DpiY,
+            pixels.DetachPixelData());
+        await encoder.FlushAsync();
+    }
+
+    private static string SanitizeFileName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return "cover";
+        var invalid = System.IO.Path.GetInvalidFileNameChars();
+        var clean = new string(name.Where(c => !invalid.Contains(c)).ToArray()).Trim();
+        return string.IsNullOrEmpty(clean) ? "cover" : clean;
+    }
+}

--- a/src/Wavee.UI.WinUI/Controls/Common/ImageZoomDialog.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Common/ImageZoomDialog.xaml.cs
@@ -11,6 +11,7 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Wavee.UI.Helpers;
+using Wavee.UI.WinUI.Data.Contracts;
 using Wavee.UI.WinUI.Data.Models;
 using Wavee.UI.WinUI.Services;
 using Windows.Graphics.Imaging;

--- a/src/Wavee.UI.WinUI/Views/AlbumPage.xaml
+++ b/src/Wavee.UI.WinUI/Views/AlbumPage.xaml
@@ -147,6 +147,10 @@
                                 CornerRadius="8"
                                 HorizontalAlignment="Stretch"
                                 SizeChanged="AlbumArtContainer_SizeChanged"
+                                Tapped="AlbumArtContainer_Tapped"
+                                PointerEntered="AlbumArtContainer_PointerEntered"
+                                PointerExited="AlbumArtContainer_PointerExited"
+                                ToolTipService.ToolTip="View cover"
                                 Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}">
                                     <Grid>
                                         <FontIcon Glyph="&#xE93C;" FontSize="64" Opacity="0.3"
@@ -157,6 +161,26 @@
                                             DecodePixelSize="280"
                                             Stretch="UniformToFill"
                                             Visibility="{x:Bind ViewModel.AlbumImageUrl, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}}"/>
+
+                                        <!-- Hover affordance: an expand hint that fades in to signal
+                                             the cover opens a zoomable viewer. Only when there's art. -->
+                                        <Border x:Name="AlbumArtHoverOverlay"
+                                                Opacity="0"
+                                                IsHitTestVisible="False"
+                                                CornerRadius="8"
+                                                Background="#26000000"
+                                                Visibility="{x:Bind ViewModel.AlbumImageUrl, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}}">
+                                            <Border Background="#B3000000"
+                                                    CornerRadius="22"
+                                                    Width="44" Height="44"
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center">
+                                                <FontIcon Glyph="&#xE740;"
+                                                          FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                          FontSize="20"
+                                                          Foreground="White"/>
+                                            </Border>
+                                        </Border>
                                     </Grid>
                                 </Border>
                             </Grid>

--- a/src/Wavee.UI.WinUI/Views/AlbumPage.xaml.cs
+++ b/src/Wavee.UI.WinUI/Views/AlbumPage.xaml.cs
@@ -21,8 +21,10 @@ using Wavee.UI.WinUI.Controls.TabBar;
 using Wavee.UI.Contracts;
 using Wavee.UI.Models;
 using Wavee.UI.Services.DragDrop;
+using Wavee.UI.WinUI.Controls.Common;
 using Wavee.UI.WinUI.Controls.ContextMenu;
 using Wavee.UI.WinUI.Controls.ContextMenu.Builders;
+using Wavee.UI.WinUI.Helpers.UI;
 using Wavee.UI.WinUI.Data.Contracts;
 using Wavee.UI.WinUI.Data.Models;
 using Wavee.UI.WinUI.Data.Parameters;
@@ -514,6 +516,33 @@ public sealed partial class AlbumPage : UserControl, ITabBarItemContent, IPageHo
         // during the loading→content transition.
         if (Math.Abs(border.Height - target) < 0.5) return;
         border.Height = target;
+    }
+
+    // ── Cover viewer (click cover → zoomable overlay with Save as…) ──
+    private static readonly Microsoft.UI.Input.InputCursor s_coverHandCursor =
+        Microsoft.UI.Input.InputSystemCursor.Create(Microsoft.UI.Input.InputSystemCursorShape.Hand);
+
+    private async void AlbumArtContainer_Tapped(object sender, TappedRoutedEventArgs e)
+    {
+        await ImageZoomDialog.ShowAsync(XamlRoot, ViewModel.AlbumImageUrl, ViewModel.AlbumName, ViewModel.AlbumName);
+    }
+
+    private void AlbumArtContainer_PointerEntered(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is UIElement el) el.ChangeCursor(s_coverHandCursor);
+        if (AlbumArtHoverOverlay is not null)
+            AnimationBuilder.Create()
+                .Opacity(to: 1, duration: TimeSpan.FromMilliseconds(140))
+                .Start(AlbumArtHoverOverlay);
+    }
+
+    private void AlbumArtContainer_PointerExited(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is UIElement el) el.ChangeCursor(null);
+        if (AlbumArtHoverOverlay is not null)
+            AnimationBuilder.Create()
+                .Opacity(to: 0, duration: TimeSpan.FromMilliseconds(140))
+                .Start(AlbumArtHoverOverlay);
     }
 
     // Same square-as-it-grows treatment for the shimmer cover so the loading

--- a/src/Wavee.UI.WinUI/Views/ShowPage.xaml
+++ b/src/Wavee.UI.WinUI/Views/ShowPage.xaml
@@ -215,6 +215,10 @@
                                     CornerRadius="8"
                                     HorizontalAlignment="Stretch"
                                     SizeChanged="CoverContainer_SizeChanged"
+                                    Tapped="CoverContainer_Tapped"
+                                    PointerEntered="CoverContainer_PointerEntered"
+                                    PointerExited="CoverContainer_PointerExited"
+                                    ToolTipService.ToolTip="View cover"
                                     Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}">
                                 <Grid>
                                     <FontIcon Glyph="&#xE93E;" FontSize="64" Opacity="0.3"
@@ -224,6 +228,25 @@
                                            DecodePixelSize="280"
                                            Stretch="UniformToFill"
                                            Visibility="{x:Bind ViewModel.CoverArtUrl, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}}"/>
+
+                                    <!-- Hover affordance: expand hint signalling the cover opens a zoomable viewer. -->
+                                    <Border x:Name="CoverHoverOverlay"
+                                            Opacity="0"
+                                            IsHitTestVisible="False"
+                                            CornerRadius="8"
+                                            Background="#26000000"
+                                            Visibility="{x:Bind ViewModel.CoverArtUrl, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}}">
+                                        <Border Background="#B3000000"
+                                                CornerRadius="22"
+                                                Width="44" Height="44"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center">
+                                            <FontIcon Glyph="&#xE740;"
+                                                      FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                      FontSize="20"
+                                                      Foreground="White"/>
+                                        </Border>
+                                    </Border>
                                 </Grid>
                             </Border>
                         </Grid>

--- a/src/Wavee.UI.WinUI/Views/ShowPage.xaml.cs
+++ b/src/Wavee.UI.WinUI/Views/ShowPage.xaml.cs
@@ -11,6 +11,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Wavee.UI.WinUI.Controls;
 using Wavee.UI.WinUI.Controls.Cards;
+using Wavee.UI.WinUI.Controls.Common;
 using Wavee.UI.WinUI.Controls.InPageFilter;
 using Wavee.UI.WinUI.Controls.PageHost;
 using Wavee.UI.WinUI.Controls.ShowEpisode;
@@ -227,6 +228,35 @@ public sealed partial class ShowPage : UserControl, ITabBarItemContent, IPageHos
     {
         if (sender is Border border && e.NewSize.Width > 0)
             border.Height = e.NewSize.Width;
+    }
+
+    // ── Cover viewer (click cover → zoomable overlay with Save as…) ──
+    private static readonly Microsoft.UI.Input.InputCursor s_coverHandCursor =
+        Microsoft.UI.Input.InputSystemCursor.Create(Microsoft.UI.Input.InputSystemCursorShape.Hand);
+
+    private async void CoverContainer_Tapped(object sender, TappedRoutedEventArgs e)
+    {
+        await ImageZoomDialog.ShowAsync(XamlRoot, ViewModel.CoverArtUrl, ViewModel.ShowName, ViewModel.ShowName);
+    }
+
+    private void CoverContainer_PointerEntered(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is UIElement el)
+            Wavee.UI.WinUI.Helpers.UI.FrameworkElementExtensions.ChangeCursor(el, s_coverHandCursor);
+        if (CoverHoverOverlay is not null)
+            AnimationBuilder.Create()
+                .Opacity(to: 1, duration: TimeSpan.FromMilliseconds(140))
+                .Start(CoverHoverOverlay);
+    }
+
+    private void CoverContainer_PointerExited(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is UIElement el)
+            Wavee.UI.WinUI.Helpers.UI.FrameworkElementExtensions.ChangeCursor(el, null);
+        if (CoverHoverOverlay is not null)
+            AnimationBuilder.Create()
+                .Opacity(to: 0, duration: TimeSpan.FromMilliseconds(140))
+                .Start(CoverHoverOverlay);
     }
 
     // ── Filter / sort dropdowns ─────────────────────────────────────────────


### PR DESCRIPTION
Click a cover to expand it in a zoomable overlay viewer with export.

- New **`ImageZoomDialog`** (`Controls/Common`): `ScrollView`-based zoom + pan (1–8×, double-click to reset) and **Save as…** (PNG/JPG, full-resolution, re-encoded to the chosen format). Theme-aware — chrome uses theme brushes and `RequestedTheme` is matched to the app theme.
- Generic + reusable: `ImageZoomDialog.ShowAsync(xamlRoot, imageUrl, title, suggestedFileName)`.
- Wired **album** and **show / podcast** covers (click to open; hover shows an expand hint + hand cursor).

Playlist / episode / other cover surfaces are a one-liner with the same call. Playlist was deferred here to avoid colliding with the open banner PR #27 that already reworks that cover.