### PR TITLE
Tint Details panel cards from album-art colour

### DIFF
--- a/src/Wavee.UI.WinUI/Controls/Playback/AudioOutputPicker.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/Playback/AudioOutputPicker.xaml.cs
@@ -63,6 +63,16 @@ public sealed partial class AudioOutputPicker : UserControl
             typeof(AudioOutputPicker),
             new PropertyMetadata(FlyoutPlacementMode.BottomEdgeAlignedLeft, OnCompactChromeChanged));
 
+    // Card-mode background override. Null keeps the default themed card brush
+    // (set in XAML); the Details panel points this at its album-tinted card
+    // brush so the "Playing on" card matches the rest of the Details stack.
+    public static readonly DependencyProperty CardBackgroundProperty =
+        DependencyProperty.Register(
+            nameof(CardBackground),
+            typeof(Brush),
+            typeof(AudioOutputPicker),
+            new PropertyMetadata(null, OnCardBackgroundChanged));
+
     private readonly ObservableCollection<AudioOutputDeviceRowViewModel> _localRows = new();
     private readonly ObservableCollection<AudioOutputDeviceRowViewModel> _connectRows = new();
     private IPlaybackStateService? _playbackStateService;
@@ -119,6 +129,12 @@ public sealed partial class AudioOutputPicker : UserControl
         set => SetValue(CompactFlyoutPlacementProperty, value);
     }
 
+    public Brush? CardBackground
+    {
+        get => (Brush?)GetValue(CardBackgroundProperty);
+        set => SetValue(CardBackgroundProperty, value);
+    }
+
     private static void OnDisplayModeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is AudioOutputPicker picker)
@@ -141,6 +157,22 @@ public sealed partial class AudioOutputPicker : UserControl
     {
         if (d is AudioOutputPicker picker)
             picker.ApplyCompactChrome();
+    }
+
+    private static void OnCardBackgroundChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not AudioOutputPicker picker || picker.CardRoot == null)
+            return;
+
+        if (e.NewValue is Brush brush)
+        {
+            picker.CardRoot.Background = brush;
+        }
+        else if (Application.Current.Resources.TryGetValue("CardBackgroundFillColorDefaultBrush", out var def)
+                 && def is Brush defaultBrush)
+        {
+            picker.CardRoot.Background = defaultBrush;
+        }
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)

--- a/src/Wavee.UI.WinUI/Controls/RightPanel/Details/DetailsTabHost.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/RightPanel/Details/DetailsTabHost.xaml.cs
@@ -292,6 +292,51 @@ public sealed partial class DetailsTabHost : UserControl
     /// chapter / snippet timers. Idempotent; the parent calls this after
     /// materialising the deferred host subtree.
     /// </summary>
+    /// <summary>
+    /// Tints the Details card stack from the current album-art colour so the
+    /// cards read as raised colour surfaces over the panel wash instead of flat
+    /// black/white. Called by the parent <c>RightPanelView</c> whenever the
+    /// extracted tint or the active theme changes. <paramref name="albumTint"/>
+    /// is the same colour the panel chrome uses (already lifted to a visible
+    /// luminance), so the card derivative stays in the same hue family.
+    /// </summary>
+    public void ApplyCardTint(Color albumTint, ElementTheme theme)
+    {
+        var key = theme == ElementTheme.Light ? "Light" : "Dark";
+        if (!Resources.ThemeDictionaries.TryGetValue(key, out var themedObj)
+            || themedObj is not ResourceDictionary themed
+            || !themed.TryGetValue("DetailsCardBrush", out var brushObj)
+            || brushObj is not AcrylicBrush brush)
+        {
+            return;
+        }
+
+        Color tint, fallback;
+        if (theme == ElementTheme.Light)
+        {
+            // Mostly white with a hint of the album hue.
+            tint = RightPanelThemeResolver.BlendColors(Colors.White, albumTint, 0.16f);
+            fallback = RightPanelThemeResolver.WithAlpha(
+                RightPanelThemeResolver.BlendColors(Colors.White, albumTint, 0.12f), 0xF4);
+        }
+        else
+        {
+            // Deep, colour-carrying surface — darker than the wash so cards lift.
+            tint = RightPanelThemeResolver.Darken(albumTint, 0.66f);
+            fallback = RightPanelThemeResolver.WithAlpha(
+                RightPanelThemeResolver.Darken(albumTint, 0.52f), 0xEA);
+        }
+
+        brush.TintColor = tint;
+        brush.FallbackColor = fallback;
+
+        // The "Playing on" device card is a separate control; point it at the
+        // same brush instance. Re-resolving the active-theme brush on every call
+        // means a Light/Dark switch re-points it correctly.
+        if (DetailsOutputDeviceCard != null)
+            DetailsOutputDeviceCard.CardBackground = brush;
+    }
+
     public void InitializeDetails()
     {
         if (_initialized) return;

--- a/src/Wavee.UI.WinUI/Controls/RightPanel/RightPanelView.xaml.cs
+++ b/src/Wavee.UI.WinUI/Controls/RightPanel/RightPanelView.xaml.cs
@@ -684,11 +684,16 @@ public sealed partial class RightPanelView : UserControl
 
     private void UpdateBackgroundChrome()
     {
+        var tintColor = RightPanelThemeResolver.GetBackgroundTintColor(
+            ActualTheme, _themeColors, _backgroundTintExtractedColor);
+
+        // Tint the Details card stack from the same album colour as the panel
+        // wash so the cards read as raised colour surfaces, not flat black/white.
+        DetailsContent?.ApplyCardTint(tintColor, ActualTheme);
+
         if (!_overlayBehavior.IsAttached)
             return;
 
-        var tintColor = RightPanelThemeResolver.GetBackgroundTintColor(
-            ActualTheme, _themeColors, _backgroundTintExtractedColor);
         var surfaceColor = RightPanelThemeResolver.GetPanelSurfaceColor(ActualTheme, _themeColors);
         var blendColor = RightPanelThemeResolver.BlendColors(
             surfaceColor,


### PR DESCRIPTION
The right-panel Details cards used a single fixed brush (near-black in dark theme), so they read as flat boxes over the album-tinted panel wash. Derive the card tint from the same extracted album colour the panel chrome uses: RightPanelView pushes the tint into DetailsTabHost.ApplyCardTint on every chrome refresh (load / theme switch / colour extraction / reset), which mutates the active-theme DetailsCardBrush so all cards update live and stay in the cover's hue family. The "Playing on" device card is a separate control, so AudioOutputPicker gains a CardBackground override pointed at the same brush. No XAML restructuring; existing card markup is unchanged.