### PR TITLE
Default library grid scale to 0.7 (slider minimum)

### DIFF
--- a/src/Wavee.UI.WinUI/Data/Models/AppSettings.cs
+++ b/src/Wavee.UI.WinUI/Data/Models/AppSettings.cs
@@ -329,7 +329,7 @@ public sealed class LibraryTabPreferences
     public string SortBy { get; set; } = "Recents";
     public string SortDirection { get; set; } = "Descending";
     public string ViewMode { get; set; } = "DefaultGrid";
-    public double GridScale { get; set; } = 1.0;
+    public double GridScale { get; set; } = 0.7;
 }
 
 public sealed class HomeSectionSettings

--- a/src/Wavee.UI.WinUI/ViewModels/Library/LibraryViewModelBase.cs
+++ b/src/Wavee.UI.WinUI/ViewModels/Library/LibraryViewModelBase.cs
@@ -20,7 +20,7 @@ public abstract partial class LibraryViewModelBase : TrackListViewModelBase
     private LibrarySortBy _sortBy = LibrarySortBy.Recents;
     private LibrarySortDirection _sortDirection = LibrarySortDirection.Descending;
     private LibraryViewMode _viewMode = LibraryViewMode.DefaultGrid;
-    private double _gridScale = 1.0;
+    private double _gridScale = 0.7;
     private bool _longLivedAttached;
 
     protected LibraryViewModelBase(
@@ -186,7 +186,7 @@ public abstract partial class LibraryViewModelBase : TrackListViewModelBase
             : LibraryViewMode.DefaultGrid;
         _gridScale = active.GridScale >= 0.5 && active.GridScale <= 2.0
             ? active.GridScale
-            : 1.0;
+            : 0.7;
         _searchQuery = searchQuery ?? "";
 
         OnPropertyChanged(nameof(SortBy));


### PR DESCRIPTION
Albums & Artists library grids now open at the smallest card size by default instead of 1.0. The scale slider's minimum is already 0.7, so the default now sits at the floor. Changed the three grid-scale defaults (LibraryTabPreferences POCO default, the VM field init, and the out-of-range prefs fallback); existing saved scales are respected. Only Albums & Artists surface the slider, so other library tabs are unaffected.