### PR TITLE
fix: implement GetYouMightAlsoLikePlaylistsAsync in MockLibraryDataService

### DIFF
--- a/src/Wavee.UI.WinUI/Services/Data/MockLibraryDataService.cs
+++ b/src/Wavee.UI.WinUI/Services/Data/MockLibraryDataService.cs
@@ -278,6 +278,11 @@ public sealed partial class MockLibraryDataService : ILibraryDataService
     public Task<AlbumPalette?> GetPlaylistPaletteAsync(string playlistId, CancellationToken ct = default)
         => Task.FromResult<AlbumPalette?>(null);
 
+    // Demo/offline mock surfaces no "You might also like" recommendations.
+    public Task<IReadOnlyList<PlaylistDetailDto>> GetYouMightAlsoLikePlaylistsAsync(
+        string playlistId, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<PlaylistDetailDto>>([]);
+
 
 
     // MovePlaylistInRootlistAsync moved to IRootlistService.


### PR DESCRIPTION
Fixes the release build for v0.1.2-alpha.1. PR #32 added `GetYouMightAlsoLikePlaylistsAsync` to `ILibraryDataService` but the demo/offline `MockLibraryDataService` wasn't updated — a semantic merge gap (no textual conflict) that surfaced as CS0535 only after #32 merged with the rest. Mock returns an empty list.