### PR TITLE
release: link every release to the issues, commits and PRs it resolves; gate it

### DIFF
--- a/.claude/skills/github-triage/SKILL.md
+++ b/.claude/skills/github-triage/SKILL.md
@@ -60,6 +60,38 @@ the form's fields (Settings › About; Settings › Diagnostics › **Copy diagn
 input glitches → `area: engine`, `status: upstream`, point at fluent-gpu. Feature requests that are really
 half-formed ideas → suggest Discussions › Ideas.
 
+## Bugfix bookkeeping (every fix, no exceptions)
+
+`ops/release/wavee-release.ps1`'s `issue refs` gate (hard) cross-checks git closing keywords against the
+CHANGELOG at release time, so every bugfix has to leave behind the same four things — the release reads and
+composes them, it never invents them:
+
+- [ ] **An issue exists.** If the report came in by chat/DM instead of a GitHub issue, create one first
+      (approval-gated — ask before running this):
+      ```powershell
+      gh issue create --repo christosk92/WaveeMusic --title "<short, user-facing summary>" `
+        --label "type: bug,area: <area>" --milestone "0.2.x Breaker" --body "<repro / context>"
+      ```
+      Use the current minor's milestone (see "New minor / new milestone" above) and at least one `area:` label
+      from the scheme above.
+- [ ] **The CHANGELOG bullet cites it.** Under `## [<next>] - unreleased`, the bullet ends with the trailing
+      group ` (#n)` — optionally ` (#n, !pr)` if a PR is also known. Only the *trailing* parenthesised group
+      counts; a mid-sentence `(#n)` is ignored by design (`- Fixed the #42 regression` does not link — put the
+      ref at the end).
+- [ ] **The commit body carries a closing keyword.** One line naming the issue: `Fixes #n` (also accepted:
+      `close(s|d)`, `fix(es|ed)`, `resolve(s|d)`, case-insensitive). This is what makes GitHub close the issue
+      when the commit lands on `main`, and it is the other half of the cross-check.
+- [ ] **A squash-merge suffix or `!N` is a PR, never an issue.** `(#N)` appended to a squashed commit's subject
+      (or `!N` anywhere) is read as a **PR** reference by the gate's parser — it never satisfies "this commit
+      fixes issue #N". Issues and PRs share one number space on GitHub, so always cite the issue explicitly with a
+      `Fixes #n` trailer; the squash suffix only ever names the PR.
+
+At release time the gate fails hard when these disagree: a commit in `<prevTag>..HEAD` fixes an issue the
+CHANGELOG entry does not cite, or the entry cites an issue no commit in range fixes. Commits without any ref are
+fine ("Other changes" in the release notes); CHANGELOG bullets without a ref are fine too but trigger the soft
+`issue coverage` warning. **Before cutting a release, run `-DryRun` and read the `issue refs` row** — it lists
+exactly what would fail, before anything is bumped or tagged.
+
 ## Changing the label set
 
 1. Edit `ops/github/labels.json` (keep the group colours; add `renameFrom` only for a rename).

--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -17,7 +17,7 @@ release is cut on the dev box by `ops/release/wavee-release.ps1`.
 #    CHANGELOG.md "## [X.Y.Z] - unreleased", ops/release/wavee/<semver>/whatsnew.json (+ media/)
 # 2. rehearse
 powershell -File ops\release\wavee-release.ps1 -DryRun -SkipTests
-# 3. ship (13 phases; the feed is repointed LAST)
+# 3. ship (14 phases; the feed is repointed LAST)
 powershell -File ops\release\wavee-release.ps1
 # failure after the tag was pushed -> re-run with -Resume; abandon -> -Abort; feed only -> -RepointFeed
 ```
@@ -78,3 +78,9 @@ zip): `docs/guide/releasing-wavee.md` §5b.
 - **`.gitignore` has `[Rr]elease/`**, so `!ops/release/` is what keeps the release tooling tracked.
 - **Testing the tooling never touches production**: `-FeedRelease wavee-stable-test -TagPrefix wavee-test-v -Branch release-test -Force -SkipTests`, or the fully local E2E harness (no GitHub at all).
 - **Packaged runs write into the package's LocalCache.** A real `%LOCALAPPDATA%\Wavee` (from an unpackaged `dotnet run`) captures a packaged app's writes; wipe it before testing a package — the startup line prints `logResolved=`.
+- **The `issue refs` gate is about consistency, not coverage.** A commit without any issue ref is fine (it lands
+  in the release notes as "Other changes"); a CHANGELOG bullet without a ref is fine too (soft `issue coverage`
+  warning only). What the hard gate refuses is *disagreement*: a `Fixes #n` commit the CHANGELOG `(#n)` doesn't
+  cite, or a `(#n)` the CHANGELOG cites that no commit in range actually closes. Fix it in whichever file is
+  wrong — CHANGELOG.md or the commit trailer — and re-run; see `github-triage`'s "Bugfix bookkeeping" section
+  for the contract that avoids ever hitting this at release time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,8 @@ this reason.
   `ReleaseNotesRange` are the pattern).
 - **No environment-variable switches** for behaviour or verification: always-on logs, the diagnostics page, gates.
 - **No legacy paths.** Replace outright; delete obsolete code. Breaking is acceptable.
+- **Every fix references its issue.** The CHANGELOG bullet ends with ` (#n)`, the commit body carries `Fixes #n`,
+  and the release script's `issue refs` gate refuses a mismatch between the two (→ `github-triage` skill).
 - **Plans with real code.** Multi-part work gets a plan in `docs/plans/wavee/*-implementation.md` with the actual
   code, component trees and ASCII wireframes; implementation is parallel subagents on disjoint files, and only the
   orchestrator builds/tests/launches.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,9 @@ docs(readme): bring back the download buttons
 Put the *why* in the body, not just the *what*. Keep PRs to one logical change — small, reviewable diffs are
 much more likely to land quickly than a large mixed one.
 
+Every fix references its issue: the commit body carries `Fixes #n`, and the release script's `issue refs` gate
+refuses a mismatch between that trailer and the CHANGELOG (→ `github-triage` skill).
+
 ## Changelog
 
 `CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). If your change is
@@ -87,6 +90,9 @@ the latest released one if it doesn't exist yet, with the appropriate `### Added
 / `### Removed` section). Write it the way the existing entries read: a bold, user-facing lead phrase followed
 by plain-language detail — not an engineering changelog. The release script refuses to ship a version without
 this heading, so a PR that changes behavior and skips it will get flagged in review.
+
+Every fix references its issue: the bullet ends with ` (#n)`, and the release script's `issue refs` gate refuses
+a mismatch between that citation and the commits it ships (→ `github-triage` skill).
 
 ## Gates before you open a PR
 

--- a/docs/guide/releasing-wavee.md
+++ b/docs/guide/releasing-wavee.md
@@ -153,7 +153,7 @@ That is the whole command. The run is a ledger of phases; each one records itsel
 |---|---|---|
 | 0 | `preflight` | the gate table below; on any hard failure nothing has happened yet |
 | 1a | `bump` | `<WaveeBuild> + 1`; `CHANGELOG.md` `unreleased` → today (UTC); asserts the diff touched **only** those two files |
-| 2 | `notes` | `Wavee.ReleaseTool validate` → `<staging>\notes\` (`whatsnew.json`, `whatsnew-index.json`, `RELEASE_BODY.md`, `store-listing.txt`, `media/`). Reads the feed's published `whatsnew-index.json` first — a 404 means "first release", and **any other failure stops the run**: phase 10 clobbers that file, so a one-entry index would erase the published history. Exit 2 also when a referenced issue/PR could not be read from GitHub (`--allow-unresolved` ships the authored title/state anyway). On failure it restores both files and un-marks the bump |
+| 2 | `notes` | `Wavee.ReleaseTool validate` → `<staging>\notes\` (`whatsnew.json`, `whatsnew-index.json`, `RELEASE_BODY.md`, `store-listing.txt`, `media/`). Reads the feed's published `whatsnew-index.json` first — a 404 means "first release", and **any other failure stops the run**: phase 10 clobbers that file, so a one-entry index would erase the published history. Exit 2 also when a referenced issue/PR could not be read from GitHub (`--allow-unresolved` ships the authored title/state anyway). When there is a previous `wavee-v*` tag, also writes `<staging>\commits.json` (every commit in `<prevTag>..HEAD`, parsed for closing keywords and PR refs) and passes it with `--previous-tag`/`--commits`, so the tool renders the `## Resolved issues` section and re-does the issue/CHANGELOG cross-check itself. On failure it restores both files and un-marks the bump |
 | 1b | `tag` | commits those two files (`release: Wavee <semver> <codename> (build <quad>)`) and creates the annotated tag — **locally** |
 | 3 | `packArm64` | `pack-wavee-msix.ps1 -Arch arm64 … -NoSign`, then asserts the package's identity name / version / arch / publisher — and that `Wavee-<quad>-win-arm64-symbols.zip` (the PDB of exactly that exe, §5b) landed next to it |
 | 4 | `packX64` | the same for x64 (or `-X64Msix <path>` to adopt a prebuilt package; its symbols zip is adopted from next to it when present, with a warning otherwise) |
@@ -164,6 +164,7 @@ That is the whole command. The run is a ledger of phases; each one records itsel
 | 9 | `release` | `gh release`: draft → upload → publish — always `--latest=false` (`releases/latest` belongs to the gallery's feed) |
 | 10 | `feed` | repoints `wavee-stable` (and `wavee-beta` if it exists) — **always last**: this is the moment installed clients see the release |
 | 11 | `verify` | assets + byte sizes vs staged, the feed live at the new quad **and pointing at this release's msix** (`MainPackage/@Uri`, not only the root `Version`), msix `Content-Length`, optional install |
+| 12 | `notify` | best-effort: comments on every GitHub issue this release's commits closed (never closes or reopens one; skips an issue that already carries a comment naming this tag). Runs **after** verify, so a failure here is `Warn`ed and the phase left incomplete — the release is already live either way; `-Resume` retries just this step |
 
 **Preflight gates** (hard unless noted): version props parse · semver + quad (a `beta` semver is refused — the beta
 channel needs its own package identity and is not built yet) · staging folder free (`-Force` replaces it, `-Resume`
@@ -173,8 +174,13 @@ exists · the PlayPlay junction is present · Windows SDK tools · x64 cross too
 `gh auth` · *(soft)* whether a `wavee-beta` feed exists and will be repointed too · **feed monotonic** (the new quad
 must be strictly greater than each feed's current root `Version`, on every architecture, and the semver must not go
 backwards — the gate itself is always hard, but an *unreachable* feed is downgraded to a warning under `-DryRun` /
-`-NoUpload`, where nothing can be published) · gates (`dotnet build Wavee.slnx` Debug **and** Release, `Wavee.Tests`, and
-the release tooling's Pester suite — the engine's VerticalSlice is the engine repo's gate).
+`-NoUpload`, where nothing can be published) · **issue refs** *(hard)* — every commit in `<prevTag>..HEAD` that
+closes an issue (`Fixes #n` / `Closes #n` / …) must be cited by the CHANGELOG `[<semver>]` entry's trailing `(#n)`
+group, and every `(#n)` the entry cites must be closed by a commit in range; disagreement fails with one line per
+mismatch (see `.claude/skills/github-triage/SKILL.md`) · **issue coverage** *(soft)* — warns when a CHANGELOG bullet
+cites no issue at all. Both SKIP on the first release of a `-TagPrefix` (there is no previous tag to range over) ·
+gates (`dotnet build Wavee.slnx` Debug **and** Release, `Wavee.Tests`, and the release tooling's Pester suite — the
+engine's VerticalSlice is the engine repo's gate).
 
 Useful switches: `-SkipTests` (skip that last gate) · `-PublicOnly` (build without PlayPlay) · `-SkipArch x64` /
 `-X64Msix <path>` · `-NoUpload` (real bump and tag, stop before pushing) · `-NoSign` (only with `-DryRun` / `-NoUpload`)
@@ -301,12 +307,14 @@ with `-Status`. Staging is `artifacts\store\<semver>\` with its own `store-state
 | Symptom | What it means | Recovery |
 |---|---|---|
 | Preflight hard-fails | nothing has happened yet | fix it and re-run |
+| `issue refs` failed | a commit's `Fixes #n` and the CHANGELOG `[<semver>]` entry's `(#n)` disagree | add the missing `(#n)` to the CHANGELOG bullet, or add the missing `Fixes #n` trailer to the commit (amend/reword before pushing); re-run. See `.claude/skills/github-triage/SKILL.md` |
 | `feed monotonic gate failed` | the new quad is not strictly greater than a live feed head | something was published out of band, or `<WaveeBuild>` was hand-edited; bump forward, never sideways |
 | Notes validation fails (exit 2) | the release is not shippable; every problem is listed | fix `whatsnew.json` / `CHANGELOG.md`. The script already restored both files and un-marked the bump — just run again |
 | Pack or signing fails | the tag exists **locally only** | fix, then `-Resume` (nothing is rebuilt, the counter is not bumped again); or `-Abort` to unwind |
 | `origin/<branch> is X but HEAD~1 is Y` | someone pushed while the release was building | rebase the release commit onto origin, then `-Resume` |
 | **Tag pushed but the upload died** | the commit and tag are public; the release may still be a draft | **`-Resume`.** Staging is hash-verified against `MANIFEST.txt` first, then the run continues from the exact phase that failed. A draft release is invisible to users, and the feed has not moved yet |
 | The feed did not come up at the new quad | GitHub asset-replacement lag | `Test-WaveeFeedLive` already retried 6 × 10 s; run `-Resume` (phase 11) |
+| `notify failed` | phase 12 could not comment on a resolved issue (`gh` hiccup, rate limit) | the release is already live and the feed already moved; `-Resume` retries just this phase |
 | A bad build shipped | — | see §7 |
 
 `-Resume` restarts at the first phase that is not `done`. `-Abort` unwinds an **un-pushed** run completely: it refuses

--- a/ops/release/Wavee.Release.psm1
+++ b/ops/release/Wavee.Release.psm1
@@ -516,6 +516,238 @@ function Set-ReleaseState {
     [IO.File]::WriteAllText($Path, ($State | ConvertTo-Json -Depth 8), (New-Utf8NoBom))
 }
 
+# ---------------------------------------------------------------------------------------------------------------
+# Release <-> issue linkage (commits, PRs, issues cross-check; see docs/plans/wavee/*-implementation.md Part A)
+#
+# The record/field separators are the ASCII RS (0x1E) / US (0x1F) control characters `git log
+# --format=%H%x1f%h%x1f%s%x1f%b%x1e` emits. Windows PowerShell 5.1 has no `` `u{...} `` escape (that is a
+# PowerShell 7+ addition), so every occurrence here is [char]0x1e / [char]0x1f instead.
+# ---------------------------------------------------------------------------------------------------------------
+
+function ConvertFrom-GitLogRecords {
+    <#
+    .SYNOPSIS
+      Parse `git log --format=%H%x1f%h%x1f%s%x1f%b%x1e` text into one record per commit. Issues = commit-body/
+      subject closing keywords (Fixes/Closes/Resolves #n, case-insensitive); Prs = a squash-merge subject suffix
+      `(#n)` or a bare `!n` anywhere in subject/body.
+    .OUTPUTS
+      Array of pscustomobject @{ Sha; Short; Subject; Issues [int[]]; Prs [int[]] }, always an array (even 0 or 1
+      element) - the caller pipes/indexes it.
+    #>
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Text)
+
+    $rs = [char]0x1e
+    $us = [char]0x1f
+    $records = @()
+    foreach ($rec in ($Text -split $rs)) {
+        if (-not $rec.Trim()) { continue }
+        $f = $rec.TrimStart("`r", "`n") -split $us, 4
+        $subject = $f[2].Trim()
+        $body = if ($f.Count -gt 3) { $f[3] } else { '' }
+        $hay = "$subject`n$body"
+
+        $issues = @([regex]::Matches($hay, '(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+#(\d+)') |
+            ForEach-Object { [int]$_.Groups[1].Value } | Sort-Object -Unique)
+
+        $prs = @()
+        $m = [regex]::Match($subject, '\(#(\d+)\)\s*$')
+        if ($m.Success) { $prs += [int]$m.Groups[1].Value }
+        $prs += @([regex]::Matches($hay, '(?<![\w/])!(\d+)\b') | ForEach-Object { [int]$_.Groups[1].Value })
+
+        $records += [pscustomobject]@{
+            Sha     = $f[0].Trim()
+            Short   = $f[1].Trim()
+            Subject = $subject
+            Issues  = @($issues)
+            Prs     = @($prs | Sort-Object -Unique)
+        }
+    }
+    , $records
+}
+
+function Get-ChangelogEntryRefs {
+    <#
+    .SYNOPSIS
+      The `## [<semver>]` CHANGELOG entry only. Same trailing-group rule as ChangelogParser.cs: a bullet's TRAILING
+      parenthesised group `(#n, !m)` at line end counts; a mid-sentence `(#n)` is ignored by design.
+    .OUTPUTS
+      pscustomobject @{ Issues [int[]]; Prs [int[]]; Bullets [int]; Unreferenced [int] }. Throws when the CHANGELOG
+      has no matching `## [<Semver>]` heading.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Changelog,
+        [Parameter(Mandatory = $true)][string]$Semver)
+
+    $rx = "(?ms)^## \[$([regex]::Escape($Semver))\][^\r\n]*\r?\n(?<body>.*?)(?=^## \[|\z)"
+    $m = [regex]::Match($Changelog, $rx)
+    if (-not $m.Success) { throw "CHANGELOG.md has no '## [$Semver]' entry" }
+
+    $issues = @()
+    $prs = @()
+    $bullets = 0
+    $unref = 0
+    foreach ($line in ($m.Groups['body'].Value -split "\r?\n")) {
+        if ($line -notmatch '^- ') { continue }
+        $bullets++
+        $g = [regex]::Match($line, '\s\((?<refs>(?:[#!]\d+(?:,\s*)?)+)\)\s*$')
+        if (-not $g.Success) { $unref++; continue }
+        foreach ($r in ($g.Groups['refs'].Value -split ',\s*')) {
+            if ($r[0] -eq '#') { $issues += [int]$r.Substring(1) }
+            else { $prs += [int]$r.Substring(1) }
+        }
+    }
+    [pscustomobject]@{
+        Issues       = @($issues | Sort-Object -Unique)
+        Prs          = @($prs | Sort-Object -Unique)
+        Bullets      = $bullets
+        Unreferenced = $unref
+    }
+}
+
+function Compare-ReleaseIssueRefs {
+    <#
+    .SYNOPSIS
+      Cross-check CHANGELOG issue refs against git-log commits over the release range. Parity with the C# side
+      (ReleaseCommits.Link): a CHANGELOG `#n` is satisfied by a commit that FIXES n OR whose squash-merge suffix
+      names PR n; only closing-keyword issues (not bare PR refs) can be "missing in the changelog".
+    .OUTPUTS
+      pscustomobject @{
+        Linked              # [pscustomobject]{ Issue; Commits } for every ChangelogIssue git can satisfy
+        MissingInChangelog  # [pscustomobject]{ Issue; Commits } - a commit closes an issue the entry never cites
+        MissingInGit        # [int[]] - the entry cites an issue no commit in range fixes or names as a PR
+        Unlinked            # commits whose Issues array is empty ("Other changes")
+      }
+    #>
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][int[]]$ChangelogIssues,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Commits)
+
+    $byRef = @{}
+    $byIssue = @{}
+    foreach ($c in $Commits) {
+        foreach ($i in $c.Issues) {
+            if (-not $byIssue.ContainsKey($i)) { $byIssue[$i] = @() }
+            $byIssue[$i] += $c
+        }
+        foreach ($n in (@($c.Issues) + @($c.Prs))) {
+            if (-not $byRef.ContainsKey($n)) { $byRef[$n] = @() }
+            $byRef[$n] += $c
+        }
+    }
+
+    $missingInChangelog = @($byIssue.Keys | Where-Object { $ChangelogIssues -notcontains $_ } | Sort-Object |
+        ForEach-Object { [pscustomobject]@{ Issue = $_; Commits = @($byIssue[$_]) } })
+    $missingInGit = @($ChangelogIssues | Where-Object { -not $byRef.ContainsKey($_) } | Sort-Object)
+    $linked = @($ChangelogIssues | Where-Object { $byRef.ContainsKey($_) } | Sort-Object |
+        ForEach-Object { [pscustomobject]@{ Issue = $_; Commits = @($byRef[$_]) } })
+
+    [pscustomobject]@{
+        Linked             = $linked
+        MissingInChangelog = $missingInChangelog
+        MissingInGit       = $missingInGit
+        Unlinked           = @($Commits | Where-Object { $_.Issues.Count -eq 0 })
+    }
+}
+
+function Format-IssueRefMismatch {
+    <#
+    .SYNOPSIS
+      One line per problem in a Compare-ReleaseIssueRefs result - the gate's throw text and the tool's error
+      parity. Empty array when there is nothing to report.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]$Comparison,
+        [string]$Semver,
+        [string]$Range)
+
+    $lines = @()
+    foreach ($m in $Comparison.MissingInChangelog) {
+        $c = ($m.Commits | ForEach-Object { "$($_.Short) `"$($_.Subject)`"" }) -join ', '
+        $lines += "issue #$($m.Issue) is fixed by $c but the CHANGELOG [$Semver] entry does not cite it"
+    }
+    foreach ($i in $Comparison.MissingInGit) {
+        $lines += "CHANGELOG [$Semver] cites #$i but no commit in $Range carries 'Fixes #$i'"
+    }
+    # Unary comma: a 1-element $lines would otherwise unroll to a bare string on return, and the caller's
+    # $lines[0] would then index a CHARACTER of that string instead of the one mismatch line.
+    , $lines
+}
+
+function Write-ReleaseCommitsJson {
+    <#  The `commits.json` file Wavee.ReleaseTool reads via --commits. camelCase keys, arrays even when empty. #>
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Commits,
+        [Parameter(Mandatory = $true)][string]$Path)
+
+    $rows = @($Commits | ForEach-Object {
+        [ordered]@{
+            sha     = $_.Sha
+            short   = $_.Short
+            subject = $_.Subject
+            issues  = @($_.Issues)
+            prs     = @($_.Prs)
+        }
+    })
+    [IO.File]::WriteAllText($Path, (ConvertTo-Json -InputObject $rows -Depth 4), (New-Utf8NoBom))
+}
+
+function New-ShippedIssueComment {
+    <#  The markdown body posted on an issue a released commit closed. #>
+    param(
+        [string]$Repo,
+        [string]$Tag,
+        [string]$Semver,
+        [string]$Codename,
+        [string]$Quad,
+        [object[]]$Commits,
+        [int[]]$Prs)
+
+    $c = ($Commits | ForEach-Object { "[$($_.Short)](https://github.com/$Repo/commit/$($_.Sha))" }) -join ', '
+    $p = if ($Prs.Count) { ' - PR ' + (($Prs | ForEach-Object { "#$_" }) -join ', ') } else { '' }
+    @(
+        "Shipped in **Wavee $Semver $([char]0x2014) $Codename** (build $Quad): https://github.com/$Repo/releases/tag/$Tag",
+        "Commits: $c$p",
+        'Sideloaded installs update automatically from the `wavee-stable` feed; Microsoft Store installs follow once the Store submission is certified.'
+    ) -join "`n`n"
+}
+
+function Test-IssueAlreadyNotified {
+    <#  Idempotency for -Resume: true when any existing comment already names this tag's release URL. #>
+    param(
+        [AllowEmptyCollection()][object[]]$Comments,
+        [string]$Repo,
+        [string]$Tag)
+
+    $needle = "https://github.com/$Repo/releases/tag/$Tag"
+    [bool]($Comments | Where-Object { "$($_.body)" -like "*$needle*" })
+}
+
+function Add-ShippedIssueComments {
+    <#
+    .SYNOPSIS
+      gh-facing (untested, like Publish-WaveeRelease): comment on every issue in $Linked (a
+      Compare-ReleaseIssueRefs .Linked array) with the body $BodyFor produces, skipping any issue already notified
+      for this tag. Never closes or reopens an issue - GitHub's own closing-keyword handling already did that.
+    .OUTPUTS
+      pscustomobject @{ Posted [int[]]; Skipped [int[]] }
+    #>
+    param(
+        [string]$Repo,
+        [string]$Tag,
+        [object[]]$Linked,
+        [scriptblock]$BodyFor)
+
+    $posted = @()
+    $skipped = @()
+    foreach ($l in $Linked) {
+        $existing = ConvertFrom-GhJson (Invoke-Gh @('api', "repos/$Repo/issues/$($l.Issue)/comments", '--paginate'))
+        if (Test-IssueAlreadyNotified -Comments $existing -Repo $Repo -Tag $Tag) { $skipped += $l.Issue; continue }
+        Invoke-Gh @('issue', 'comment', "$($l.Issue)", '--repo', $Repo, '--body', (& $BodyFor $l)) | Out-Null
+        $posted += $l.Issue
+    }
+    [pscustomobject]@{ Posted = @($posted); Skipped = @($skipped) }
+}
+
 Export-ModuleMember -Function @(
     'Set-WaveeTls12',
     'Test-WaveeSemver',
@@ -536,4 +768,12 @@ Export-ModuleMember -Function @(
     'Publish-WaveeRelease',
     'Update-WaveeFeed',
     'Get-ReleaseState',
-    'Set-ReleaseState')
+    'Set-ReleaseState',
+    'ConvertFrom-GitLogRecords',
+    'Get-ChangelogEntryRefs',
+    'Compare-ReleaseIssueRefs',
+    'Format-IssueRefMismatch',
+    'Write-ReleaseCommitsJson',
+    'New-ShippedIssueComment',
+    'Test-IssueAlreadyNotified',
+    'Add-ShippedIssueComments')

--- a/ops/release/tests/Wavee.ReleaseRefs.Tests.ps1
+++ b/ops/release/tests/Wavee.ReleaseRefs.Tests.ps1
@@ -1,0 +1,352 @@
+#requires -Version 5.1
+<#
+    Pester 3.4 (the version that ships with Windows PowerShell 5.1 - Describe / Context / It / Should Be /
+    Should BeExactly / Should Throw / Should Match), matching Wavee.Release.Tests.ps1 in this folder. Run with:
+
+        Invoke-Pester -Path ops/release/tests/Wavee.ReleaseRefs.Tests.ps1
+
+    Covers the release <-> issue linkage helpers added to Wavee.Release.psm1 (docs/plans/wavee/*-implementation.md
+    Part A): parsing `git log --format=%H%x1f%h%x1f%s%x1f%b%x1e` text, extracting the trailing-group refs from one
+    CHANGELOG entry, cross-checking the two, formatting the mismatch lines, the commits.json shape and the
+    shipped-issue-comment helpers. Pure: no git, no gh, no network - Add-ShippedIssueComments (the one gh-facing
+    function) is intentionally NOT tested here.
+#>
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $here '..\..\..')).Path
+
+Import-Module (Join-Path $repoRoot 'ops\release\Wavee.Release.psm1') -Force -DisableNameChecking
+# Build module LAST: the release module's nested -Force import would otherwise unload these exports from the test scope.
+Import-Module (Join-Path $repoRoot 'ops\build\Wavee.Build.psm1') -Force -DisableNameChecking
+
+$script:RS = [char]0x1e
+$script:US = [char]0x1f
+
+function New-GitLogText {
+    <#  Builds the exact text `git log --format=%H%x1f%h%x1f%s%x1f%b%x1e` emits for a list of
+        @{ Sha; Short; Subject; Body } records - each record's formatted output is followed by a newline before
+        the next record's RS-separated fields begin (git's default per-commit trailing newline). #>
+    param([object[]]$Records)
+
+    $sb = New-Object System.Text.StringBuilder
+    foreach ($r in $Records) {
+        [void]$sb.Append($r.Sha).Append($script:US).Append($r.Short).Append($script:US).Append($r.Subject).Append($script:US).Append($r.Body).Append($script:RS).Append("`n")
+    }
+    $sb.ToString()
+}
+
+# ===================================================================================================================
+
+Describe 'ConvertFrom-GitLogRecords' {
+
+    It 'parses a closing keyword in the body as an Issue' {
+        $text = New-GitLogText @(@{ Sha = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2'; Short = 'a1b2c3d'; Subject = 'audio: fix xrun logging'; Body = "Fixes #48`n" })
+        $r = ConvertFrom-GitLogRecords $text
+        $r.Count | Should Be 1
+        $r[0].Sha | Should BeExactly 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2'
+        $r[0].Short | Should BeExactly 'a1b2c3d'
+        $r[0].Issues.Count | Should Be 1
+        $r[0].Issues[0] | Should Be 48
+        $r[0].Prs.Count | Should Be 0
+    }
+
+    It 'parses "closes #n" (case-insensitive) in the body as an Issue' {
+        $text = New-GitLogText @(@{ Sha = 'b'*40; Short = 'bbbbbbb'; Subject = 'store: fix submission bug'; Body = "CLOSES #41`n" })
+        $r = ConvertFrom-GitLogRecords $text
+        $r[0].Issues.Count | Should Be 1
+        $r[0].Issues[0] | Should Be 41
+    }
+
+    It 'a commit with no closing keyword has an empty Issues array' {
+        $text = New-GitLogText @(@{ Sha = 'c'*40; Short = 'ccccccc'; Subject = 'chore: tidy comments'; Body = '' })
+        $r = ConvertFrom-GitLogRecords $text
+        $r[0].Issues.Count | Should Be 0
+        , $r[0].Issues | Should BeOfType ([array])
+    }
+
+    It 'three commits in one log - Fixes / closes / none - parse independently' {
+        $text = New-GitLogText @(
+            @{ Sha = 'a'*40; Short = 'aaaaaaa'; Subject = 'fix a'; Body = "Fixes #48`n" },
+            @{ Sha = 'b'*40; Short = 'bbbbbbb'; Subject = 'fix b'; Body = "closes #41`n" },
+            @{ Sha = 'c'*40; Short = 'ccccccc'; Subject = 'chore: c'; Body = '' }
+        )
+        $r = ConvertFrom-GitLogRecords $text
+        $r.Count | Should Be 3
+        $r[0].Issues[0] | Should Be 48
+        $r[1].Issues[0] | Should Be 41
+        $r[2].Issues.Count | Should Be 0
+    }
+
+    It 'a squash-merge subject suffix (#49) is a Pr, not an Issue' {
+        $text = New-GitLogText @(@{ Sha = 'd'*40; Short = 'ddddddd'; Subject = 'audio: adaptive read-ahead (#49)'; Body = '' })
+        $r = ConvertFrom-GitLogRecords $text
+        $r[0].Issues.Count | Should Be 0
+        $r[0].Prs.Count | Should Be 1
+        $r[0].Prs[0] | Should Be 49
+    }
+
+    It 'a bare !52 anywhere is a Pr' {
+        $text = New-GitLogText @(@{ Sha = 'e'*40; Short = 'eeeeeee'; Subject = 'merge branch'; Body = "see !52 for context`n" })
+        $r = ConvertFrom-GitLogRecords $text
+        $r[0].Prs.Count | Should Be 1
+        $r[0].Prs[0] | Should Be 52
+    }
+
+    It 'prose mentioning "PR #32 added..." is not read as a closing keyword' {
+        $text = New-GitLogText @(@{ Sha = 'f'*40; Short = 'fffffff'; Subject = 'docs: mention PR #32 added a knob'; Body = '' })
+        $r = ConvertFrom-GitLogRecords $text
+        $r[0].Issues.Count | Should Be 0
+    }
+
+    It 'keyword matching is case-insensitive (Fix/FIX/fix)' {
+        $text = New-GitLogText @(
+            @{ Sha = '1'*40; Short = '1111111'; Subject = 'a'; Body = "Fix #10`n" },
+            @{ Sha = '2'*40; Short = '2222222'; Subject = 'b'; Body = "FIX #11`n" },
+            @{ Sha = '3'*40; Short = '3333333'; Subject = 'c'; Body = "fix #12`n" }
+        )
+        $r = ConvertFrom-GitLogRecords $text
+        $r[0].Issues[0] | Should Be 10
+        $r[1].Issues[0] | Should Be 11
+        $r[2].Issues[0] | Should Be 12
+    }
+
+    It 'empty text yields an empty array' {
+        $r = ConvertFrom-GitLogRecords ''
+        $r.Count | Should Be 0
+    }
+}
+
+# ===================================================================================================================
+
+Describe 'Get-ChangelogEntryRefs' {
+
+    $script:Changelog = @'
+# Changelog
+
+## [0.2.6] - unreleased
+- audio: fix xrun logging (#48)
+- store: fix submission bug (#48, !52)
+- chore: tidy comments
+- docs: mention issue (#412) mid-sentence, not a ref
+
+## [0.2.5] - 2026-08-30
+- audio: adaptive read-ahead (#99)
+'@
+
+    It 'picks only the [0.2.6] entry, ignoring refs in [0.2.5] below it' {
+        $r = Get-ChangelogEntryRefs -Changelog $script:Changelog -Semver '0.2.6'
+        $r.Issues -contains 99 | Should Be $false
+    }
+
+    It 'reads the trailing group (#48) as an Issue' {
+        $r = Get-ChangelogEntryRefs -Changelog $script:Changelog -Semver '0.2.6'
+        $r.Issues -contains 48 | Should Be $true
+    }
+
+    It 'ignores a mid-sentence (#412) - parity with ChangelogParserTests.cs:186' {
+        $r = Get-ChangelogEntryRefs -Changelog $script:Changelog -Semver '0.2.6'
+        $r.Issues -contains 412 | Should Be $false
+    }
+
+    It 'splits a trailing group "(#48, !52)" into an Issue and a Pr' {
+        $r = Get-ChangelogEntryRefs -Changelog $script:Changelog -Semver '0.2.6'
+        $r.Issues -contains 48 | Should Be $true
+        $r.Prs -contains 52 | Should Be $true
+    }
+
+    It 'counts Bullets and Unreferenced' {
+        $r = Get-ChangelogEntryRefs -Changelog $script:Changelog -Semver '0.2.6'
+        $r.Bullets | Should Be 4
+        $r.Unreferenced | Should Be 2
+    }
+
+    It 'throws when the semver has no matching entry' {
+        { Get-ChangelogEntryRefs -Changelog $script:Changelog -Semver '9.9.9' } | Should Throw
+    }
+}
+
+# ===================================================================================================================
+
+Describe 'Compare-ReleaseIssueRefs' {
+
+    function New-Commit {
+        param([string]$Short, [int[]]$Issues = @(), [int[]]$Prs = @())
+        [pscustomobject]@{ Sha = $Short + ('0' * 33); Short = $Short; Subject = "commit $Short"; Issues = @($Issues); Prs = @($Prs) }
+    }
+
+    It 'a commit fixing an issue the CHANGELOG cites is Linked' {
+        $commits = @(New-Commit -Short 'a1b2c3d' -Issues @(48))
+        $r = Compare-ReleaseIssueRefs -ChangelogIssues @(48) -Commits $commits
+        $r.Linked.Count | Should Be 1
+        $r.Linked[0].Issue | Should Be 48
+        $r.MissingInChangelog.Count | Should Be 0
+        $r.MissingInGit.Count | Should Be 0
+    }
+
+    It 'a commit fixing an issue the CHANGELOG does not cite is MissingInChangelog' {
+        $commits = @(New-Commit -Short 'a1b2c3d' -Issues @(48))
+        $r = Compare-ReleaseIssueRefs -ChangelogIssues @() -Commits $commits
+        $r.MissingInChangelog.Count | Should Be 1
+        $r.MissingInChangelog[0].Issue | Should Be 48
+        $r.Linked.Count | Should Be 0
+    }
+
+    It 'a CHANGELOG-cited issue no commit fixes is MissingInGit' {
+        $r = Compare-ReleaseIssueRefs -ChangelogIssues @(48) -Commits @()
+        $r.MissingInGit.Count | Should Be 1
+        $r.MissingInGit[0] | Should Be 48
+        $r.Linked.Count | Should Be 0
+    }
+
+    It 'both a missing-in-changelog and a missing-in-git can occur in the same comparison' {
+        $commits = @(New-Commit -Short 'a1b2c3d' -Issues @(48))
+        $r = Compare-ReleaseIssueRefs -ChangelogIssues @(41) -Commits $commits
+        $r.MissingInChangelog.Count | Should Be 1
+        $r.MissingInChangelog[0].Issue | Should Be 48
+        $r.MissingInGit.Count | Should Be 1
+        $r.MissingInGit[0] | Should Be 41
+    }
+
+    It 'a CHANGELOG issue satisfied only by a commit''s Pr ref (squash suffix) is Linked, not MissingInGit' {
+        $commits = @(New-Commit -Short 'a1b2c3d' -Prs @(48))
+        $r = Compare-ReleaseIssueRefs -ChangelogIssues @(48) -Commits $commits
+        $r.Linked.Count | Should Be 1
+        $r.MissingInGit.Count | Should Be 0
+        # A pr-only ref must not surface as MissingInChangelog (only closing-keyword Issues can).
+        $r.MissingInChangelog.Count | Should Be 0
+    }
+
+    It 'a commit citing nothing is Unlinked' {
+        $commits = @(New-Commit -Short 'a1b2c3d')
+        $r = Compare-ReleaseIssueRefs -ChangelogIssues @() -Commits $commits
+        $r.Unlinked.Count | Should Be 1
+        $r.Unlinked[0].Short | Should BeExactly 'a1b2c3d'
+    }
+
+    It 'handles an empty commit list and an empty CHANGELOG issue list without throwing' {
+        { Compare-ReleaseIssueRefs -ChangelogIssues @() -Commits @() } | Should Not Throw
+        $r = Compare-ReleaseIssueRefs -ChangelogIssues @() -Commits @()
+        $r.Linked.Count | Should Be 0
+        $r.MissingInChangelog.Count | Should Be 0
+        $r.MissingInGit.Count | Should Be 0
+        $r.Unlinked.Count | Should Be 0
+    }
+}
+
+# ===================================================================================================================
+
+Describe 'Format-IssueRefMismatch' {
+
+    function New-Commit {
+        param([string]$Short, [string]$Subject, [int[]]$Issues = @())
+        [pscustomobject]@{ Sha = $Short + ('0' * 33); Short = $Short; Subject = $Subject; Issues = @($Issues); Prs = @() }
+    }
+
+    It 'formats a MissingInChangelog entry naming the commit short SHA and subject' {
+        $commits = @(New-Commit -Short 'a1b2c3d' -Subject 'audio: fix xrun logging' -Issues @(48))
+        $cmp = Compare-ReleaseIssueRefs -ChangelogIssues @() -Commits $commits
+        $lines = Format-IssueRefMismatch -Comparison $cmp -Semver '0.2.6' -Range 'wavee-v0.2.5..HEAD'
+        $lines.Count | Should Be 1
+        $lines[0] | Should Match 'issue #48 is fixed by a1b2c3d "audio: fix xrun logging" but the CHANGELOG \[0\.2\.6\] entry does not cite it'
+    }
+
+    It 'formats a MissingInGit entry naming the semver and the range' {
+        $cmp = Compare-ReleaseIssueRefs -ChangelogIssues @(48) -Commits @()
+        $lines = Format-IssueRefMismatch -Comparison $cmp -Semver '0.2.6' -Range 'wavee-v0.2.5..HEAD'
+        $lines.Count | Should Be 1
+        $lines[0] | Should BeExactly "CHANGELOG [0.2.6] cites #48 but no commit in wavee-v0.2.5..HEAD carries 'Fixes #48'"
+    }
+
+    It 'returns an empty array when the comparison has nothing to report' {
+        $cmp = Compare-ReleaseIssueRefs -ChangelogIssues @() -Commits @()
+        $lines = Format-IssueRefMismatch -Comparison $cmp -Semver '0.2.6' -Range 'wavee-v0.2.5..HEAD'
+        $lines.Count | Should Be 0
+    }
+}
+
+# ===================================================================================================================
+
+Describe 'Write-ReleaseCommitsJson' {
+
+    $script:TmpRoot = Join-Path $env:TEMP ('wavee-releaserefs-tests-' + [guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Force -Path $script:TmpRoot | Out-Null
+
+    It 'writes camelCase keys and arrays even when Issues/Prs are empty' {
+        $out = Join-Path $script:TmpRoot 'commits.json'
+        $commits = @(
+            [pscustomobject]@{ Sha = 'a'*40; Short = 'aaaaaaa'; Subject = 'fix a'; Issues = @(48); Prs = @() },
+            [pscustomobject]@{ Sha = 'b'*40; Short = 'bbbbbbb'; Subject = 'chore b'; Issues = @(); Prs = @() }
+        )
+        Write-ReleaseCommitsJson -Commits $commits -Path $out
+        Test-Path $out | Should Be $true
+        $json = Get-Content -Raw -Path $out | ConvertFrom-Json
+        $json.Count | Should Be 2
+        $json[0].sha | Should BeExactly ('a'*40)
+        $json[0].short | Should BeExactly 'aaaaaaa'
+        $json[0].subject | Should BeExactly 'fix a'
+        , $json[0].issues | Should BeOfType ([array])
+        $json[0].issues[0] | Should Be 48
+        , $json[1].issues | Should Not Be $null
+        $json[1].issues.Count | Should Be 0
+        $json[1].prs.Count | Should Be 0
+    }
+
+    It 'writes an empty JSON array (not null) for an empty commit list' {
+        $out = Join-Path $script:TmpRoot 'commits-empty.json'
+        Write-ReleaseCommitsJson -Commits @() -Path $out
+        $text = Get-Content -Raw -Path $out
+        # Windows PowerShell 5.1's ConvertTo-Json renders an empty array as "[\r\n\r\n]" rather than "[]" - assert
+        # on the brackets (not-null, not the bare literal "null") rather than the exact whitespace between them.
+        $text.TrimStart().StartsWith('[') | Should Be $true
+        $text.TrimEnd().EndsWith(']') | Should Be $true
+        $text.Trim() | Should Not BeExactly 'null'
+    }
+}
+
+# ===================================================================================================================
+
+Describe 'New-ShippedIssueComment' {
+
+    It 'contains the release tag URL, every short SHA and the PR reference' {
+        $commits = @(
+            [pscustomobject]@{ Sha = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2'; Short = 'a1b2c3d'; Subject = 'fix a'; Issues = @(48); Prs = @(52) },
+            [pscustomobject]@{ Sha = 'b1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2'; Short = 'b1b2c3d'; Subject = 'fix b'; Issues = @(48); Prs = @() }
+        )
+        $body = New-ShippedIssueComment -Repo 'christosk92/WaveeMusic' -Tag 'wavee-v0.2.6' -Semver '0.2.6' -Codename 'Breaker' -Quad '0.2.6.1' -Commits $commits -Prs @(52)
+
+        $body | Should Match ([regex]::Escape('https://github.com/christosk92/WaveeMusic/releases/tag/wavee-v0.2.6'))
+        $body | Should Match ([regex]::Escape('a1b2c3d'))
+        $body | Should Match ([regex]::Escape('b1b2c3d'))
+        $body | Should Match 'PR #52'
+    }
+
+    It 'omits the PR clause entirely when there are no PRs' {
+        $commits = @([pscustomobject]@{ Sha = 'a'*40; Short = 'aaaaaaa'; Subject = 'fix a'; Issues = @(48); Prs = @() })
+        $body = New-ShippedIssueComment -Repo 'christosk92/WaveeMusic' -Tag 'wavee-v0.2.6' -Semver '0.2.6' -Codename 'Breaker' -Quad '0.2.6.1' -Commits $commits -Prs @()
+        $body | Should Not Match 'PR #'
+    }
+}
+
+# ===================================================================================================================
+
+Describe 'Test-IssueAlreadyNotified' {
+
+    It 'is true when a comment body already contains this tag''s release URL' {
+        $comments = @([pscustomobject]@{ body = 'Shipped in Wavee 0.2.5: https://github.com/christosk92/WaveeMusic/releases/tag/wavee-v0.2.5 - enjoy!' })
+        (Test-IssueAlreadyNotified -Comments $comments -Repo 'christosk92/WaveeMusic' -Tag 'wavee-v0.2.5') | Should Be $true
+    }
+
+    It 'is false when no comment mentions this tag' {
+        $comments = @([pscustomobject]@{ body = 'thanks for the report' })
+        (Test-IssueAlreadyNotified -Comments $comments -Repo 'christosk92/WaveeMusic' -Tag 'wavee-v0.2.5') | Should Be $false
+    }
+
+    It 'is false for an empty comment list' {
+        (Test-IssueAlreadyNotified -Comments @() -Repo 'christosk92/WaveeMusic' -Tag 'wavee-v0.2.5') | Should Be $false
+    }
+
+    It 'does not false-positive on a different tag''s release URL' {
+        $comments = @([pscustomobject]@{ body = 'Shipped in Wavee 0.2.4: https://github.com/christosk92/WaveeMusic/releases/tag/wavee-v0.2.4' })
+        (Test-IssueAlreadyNotified -Comments $comments -Repo 'christosk92/WaveeMusic' -Tag 'wavee-v0.2.5') | Should Be $false
+    }
+}

--- a/ops/release/wavee-release.ps1
+++ b/ops/release/wavee-release.ps1
@@ -25,6 +25,9 @@
       9  release       gh release: draft -> upload -> publish
       10 feed          repoint the rolling feed release(s) - ALWAYS LAST, it is what clients poll
       11 verify        assets + sizes vs staged, feed root Version live, msix Content-Length, optional install
+      12 notify        comment on every GitHub issue this release's commits closed (best-effort, after verify;
+                        never closes or reopens an issue - -Resume retries a failed notify, -Abort never touches it
+                        because it only runs after the release is already published)
 
 .EXAMPLE
   powershell -NoProfile -ExecutionPolicy Bypass -File ops\release\wavee-release.ps1 -DryRun -SkipTests
@@ -383,6 +386,12 @@ if ($Resume) {
     $Channel = "$($script:State.channel)"
     $arches = @($script:State.arches)
     $feeds = @($script:State.feeds)
+    # The issue-refs gate normally computes this fresh in the preflight block below, but a -Resume that finds
+    # 'preflight' already done skips that block entirely - so the ledger value (persisted by that same block, or
+    # $null on a release cut before this feature existed) is the only source left for phase 2 / phase 12.
+    $previousTag = $null
+    if ($script:State.ContainsKey('previousTag') -and $script:State.previousTag) { $previousTag = "$($script:State.previousTag)" }
+    $range = "$previousTag..HEAD"
     Step "Resume $tag (build $quad)"
     Note "staging $stage"
     if (Test-PhaseDone 'stage') {
@@ -470,6 +479,17 @@ if (-not (Test-PhaseDone 'preflight')) {
         }
         $head.Substring(0, 7)
     }
+
+    # Previous release tag and commit range, computed once at SCRIPT scope (not inside a check scriptblock) so the
+    # issue-refs checks below, Invoke-Notes (phase 2) and Invoke-Notify (phase 12) all see the same value. The first
+    # release of a given -TagPrefix has none - $previousTag stays $null and every consumer treats that as "nothing
+    # to range over" rather than a failure. Persisted into the ledger so a -Resume that skips this block (preflight
+    # already 'done') can still recover it.
+    $previousTag = (Invoke-Git @('describe', '--tags', '--abbrev=0', '--match', "$TagPrefix*") -AllowFailure).Text
+    if (-not $previousTag) { $previousTag = $null }
+    $range = "$previousTag..HEAD"
+    $script:State.previousTag = $previousTag
+
     Add-Check 'tag is free' 'hard' {
         if ($DryRun) { return 'SKIP: -DryRun never tags' }
         if ((Invoke-Git @('tag', '-l', $tag)).Text) { throw "tag $tag already exists locally" }
@@ -485,6 +505,30 @@ if (-not (Test-PhaseDone 'preflight')) {
         $m = [regex]::Match($cl, $rx)
         if (-not $m.Success) { throw "CHANGELOG.md has no '## [$semver] - <date|unreleased>' heading" }
         $m.Groups[1].Value
+    }
+    Add-Check 'issue refs' 'hard' {
+        <#
+            The bugfix-bookkeeping contract (.claude/skills/github-triage/SKILL.md): a commit that closes an issue
+            in $range and the CHANGELOG [$semver] entry that cites it must agree. Disagreement fails hard - it is
+            the whole point of the gate - because an uncited fix ships without the "shipped" comment the issue
+            reporter is owed, and a citation nothing actually fixed just lies to the CHANGELOG's readers.
+        #>
+        if (-not $previousTag) { return "SKIP: no $TagPrefix* tag yet, nothing to range" }
+        $log = (Invoke-Git @('log', '--format=%H%x1f%h%x1f%s%x1f%b%x1e', $range)).Text
+        $script:Commits = ConvertFrom-GitLogRecords $log
+        $refs = Get-ChangelogEntryRefs -Changelog (Get-Content $changelogPathRepo -Raw) -Semver $semver
+        $script:Refs = Compare-ReleaseIssueRefs -ChangelogIssues $refs.Issues -Commits $script:Commits
+        $bad = Format-IssueRefMismatch $script:Refs $semver $range
+        if ($bad.Count) { throw ($bad -join ' / ') }
+        "$($script:Refs.Linked.Count) issue(s) linked, $($script:Refs.Unlinked.Count) commit(s) without an issue, since $previousTag"
+    }
+    Add-Check 'issue coverage' 'soft' {
+        # Soft: a commit (or a bullet) with no issue at all is fine - not every change is a bugfix - this only
+        # warns so an author notices a whole release with no bookkeeping at all.
+        if (-not $previousTag) { return 'SKIP: first release' }
+        $refs = Get-ChangelogEntryRefs -Changelog (Get-Content $changelogPathRepo -Raw) -Semver $semver
+        if ($refs.Unreferenced) { throw "$($refs.Unreferenced) of $($refs.Bullets) CHANGELOG bullet(s) cite no issue" }
+        "all $($refs.Bullets) bullet(s) cite an issue"
     }
     Add-Check 'release notes' 'hard' {
         if ($NoNotes) {
@@ -695,14 +739,16 @@ function Invoke-Notes {
         New-Item -ItemType Directory -Force -Path $notesSrc | Out-Null
         $reused = [ordered]@{
             schema = $prevDoc.schema; product = $prevDoc.product
-            version = ''; packageVersion = ''; name = $codename
+            version = $semver; packageVersion = ''; name = $codename   # the tool asserts version == --semver (an authored file carries it too)
             tagline = $prevDoc.tagline; date = ''; channel = $Channel; lang = $prevDoc.lang
             minOs = $prevDoc.minOs; arch = $prevDoc.arch
             links = [ordered]@{ release = ''; changelog = ''; compare = '' }
             highlights = $prevDoc.highlights; sections = @()
             notices = $prevDoc.notices; media = @(); generatedAt = ''
         }
-        ($reused | ConvertTo-Json -Depth 10) | Set-Content -Path (Join-Path $notesSrc 'whatsnew.json') -Encoding utf8
+        # WriteAllText with a BOM-less encoding: Windows PowerShell's `-Encoding utf8` prepends a BOM, and
+        # Wavee.ReleaseTool's JSON reader (System.Text.Json over raw bytes) rejects it as '0xEF is an invalid start'.
+        [IO.File]::WriteAllText((Join-Path $notesSrc 'whatsnew.json'), ($reused | ConvertTo-Json -Depth 10), (New-Object System.Text.UTF8Encoding($false)))
         $prevMedia = Join-Path $prevDir.FullName 'media'
         if (Test-Path $prevMedia) { Copy-Item $prevMedia (Join-Path $notesSrc 'media') -Recurse -Force }
         Warn "running with -NoNotes: reusing $($prevDir.Name)'s tagline/highlights for $semver (sections still derive from THIS release's CHANGELOG.md entry)"
@@ -731,6 +777,20 @@ function Invoke-Notes {
             '--out', $notesOut,
             '--repo', $Repo)
         if ($prev) { $toolArgs += @('--previous-index', $prev) }
+        if ($previousTag) {
+            # $script:Commits is normally populated by the 'issue refs' preflight check that just ran in this same
+            # process; a -Resume that finds 'preflight' already 'done' never runs that check, so it is recomputed
+            # here from the same $range for the one case that matters: re-running just this phase after it failed.
+            # Wavee.ReleaseTool re-does the cross-check itself (authoritative - it also knows the GitHub issue
+            # state); this file exists so a bad range dies here, before the version bump is committed.
+            if (-not $script:Commits) {
+                $log = (Invoke-Git @('log', '--format=%H%x1f%h%x1f%s%x1f%b%x1e', $range)).Text
+                $script:Commits = ConvertFrom-GitLogRecords $log
+            }
+            $commitsPath = Join-Path $stage 'commits.json'
+            Write-ReleaseCommitsJson $script:Commits $commitsPath
+            $toolArgs += @('--previous-tag', $previousTag, '--commits', $commitsPath)
+        }
 
         # The token reaches the child process through the environment only: it never lands in a command line, a
         # transcript, or release-state.json. Get-GhAuthToken owns the parsing (gh prints notices on stderr) and
@@ -1055,6 +1115,25 @@ if ($DryRun -or $NoUpload) {
     foreach ($f in $feeds) {
         Write-Host "   gh release upload $f --repo $Repo --clobber $(($feedPaths | ForEach-Object { '"' + $_ + '"' }) -join ' ')"
     }
+
+    if ($script:Refs -and $script:Refs.Linked.Count -gt 0) {
+        Write-Host ''
+        Step 'Resolved issues (preview)'
+        $script:Refs.Linked | ForEach-Object {
+            [pscustomobject]@{
+                Issue   = "#$($_.Issue)"
+                Commits = (($_.Commits | ForEach-Object { $_.Short }) -join ', ')
+                Prs     = (($_.Commits.Prs | Sort-Object -Unique | ForEach-Object { "#$_" }) -join ', ')
+            }
+        } | Format-Table -AutoSize | Out-String -Width 200 | Write-Host
+        Write-Host '   A real run comments on each of these after verify (phase 12 notify), never closes or reopens:' -ForegroundColor DarkGray
+        foreach ($l in $script:Refs.Linked) {
+            $prs = @($l.Commits.Prs | Sort-Object -Unique)
+            $body = New-ShippedIssueComment -Repo $Repo -Tag $tag -Semver $semver -Codename $codename -Quad $quad -Commits $l.Commits -Prs $prs
+            Write-Host "   gh issue comment $($l.Issue) --repo $Repo --body `"$($body -replace "`r?`n", '\n')`""
+        }
+    }
+
     Write-Host ''
     Good "dry run complete: $stage"
     return
@@ -1212,6 +1291,48 @@ else {
 }
 
 # ===============================================================================================================
+# 12  notify (comment on every GitHub issue this release's commits closed)
+# ===============================================================================================================
+
+function Invoke-Notify {
+    Step 'Comment on resolved issues'
+    if (-not $previousTag) { Note 'no previous tag; nothing to link'; return }
+    if (-not $script:Refs) {
+        # A -Resume that found 'preflight' already 'done' never ran the 'issue refs' check in this process, so
+        # $script:Refs is still $null here even though $previousTag came back from the ledger. Recompute it from
+        # the same range rather than skip: the release is already live, so this is the one chance to notify.
+        $log = (Invoke-Git @('log', '--format=%H%x1f%h%x1f%s%x1f%b%x1e', $range)).Text
+        $commits = ConvertFrom-GitLogRecords $log
+        $refs = Get-ChangelogEntryRefs -Changelog (Get-Content $changelogPathRepo -Raw) -Semver $semver
+        $script:Refs = Compare-ReleaseIssueRefs -ChangelogIssues $refs.Issues -Commits $commits
+    }
+    if ($script:Refs.Linked.Count -eq 0) { Note 'no linked issues'; return }
+    $bodyFor = {
+        param($l)
+        New-ShippedIssueComment -Repo $Repo -Tag $tag -Semver $semver -Codename $codename -Quad $quad `
+            -Commits $l.Commits -Prs @($l.Commits.Prs | Sort-Object -Unique)
+    }
+    $r = Add-ShippedIssueComments -Repo $Repo -Tag $tag -Linked $script:Refs.Linked -BodyFor $bodyFor
+    Good "commented on #$($r.Posted -join ', #')$(if ($r.Skipped) { " (already: #$($r.Skipped -join ', #'))" })"
+}
+
+if (-not (Test-PhaseDone 'notify')) {
+    # Best-effort by design: the release is already published (phase 9) and the feed already repointed (phase 10)
+    # by the time this runs, so a comment failure must never look like the release itself failed. The phase is
+    # left incomplete on failure so -Resume retries just this step.
+    try {
+        Invoke-Notify
+        Complete-Phase 'notify'
+    }
+    catch {
+        Warn "notify failed: $($_.Exception.Message -replace "`r?`n", ' / ') ($tag is already live; -Resume to retry)"
+    }
+}
+else {
+    Note 'issues already notified'
+}
+
+# ===============================================================================================================
 # Summary
 # ===============================================================================================================
 
@@ -1223,6 +1344,8 @@ Step 'Summary'
     Channel  = $Channel
     Branch   = $Branch
     Commit   = $commit
+    Since    = if ($previousTag) { $previousTag } else { '(first release)' }
+    Issues   = if ($script:Refs -and $script:Refs.Linked.Count -gt 0) { ($script:Refs.Linked | ForEach-Object { "#$($_.Issue)" }) -join ', ' } else { '(none)' }
     Staging  = $stage
     Release  = "https://github.com/$Repo/releases/tag/$tag"
 } | Format-List | Out-String -Width 200 | Write-Host

--- a/ops/release/wavee/README.md
+++ b/ops/release/wavee/README.md
@@ -24,6 +24,7 @@ document with the dated `CHANGELOG.md` entry and stamps the rest.
 | `packageVersion`, `date`, `channel` | the tool (from `--quad` / the CHANGELOG date / `--channel`) |
 | `sections` | the tool — parsed from the `## [<semver>]` entry in `CHANGELOG.md`. **Leave it `[]`.** |
 | `links`, `generatedAt`, `media` (hashes), issue/PR `title`/`state`/`stateReason`/`merged` | the tool |
+| a section item's `commits`, the document's `unlinkedCommits`, an index entry's `issues` | the tool — derived from `--commits` (`<staging>\commits.json`, written by the release script from `git log <prevTag>..HEAD`) and the closing-keyword / squash-suffix parse. Nothing here to author |
 
 So the changelog stays the single human source of the itemised list, and `whatsnew.json` is only the editorial
 layer on top of it. Writing bullets into `sections` by hand is silently overwritten.
@@ -62,6 +63,14 @@ layer on top of it. Writing bullets into `sections` by hand is silently overwrit
   closed weeks ago. That is exit 2: `N issue(s) unresolved`. Fix it with a token (`--github-token`, or `GITHUB_TOKEN`
   in the environment, which is how the release script passes it); `--allow-unresolved` is the deliberate escape
   hatch for "GitHub is down and this release has to go out anyway".
+- **Cross-checked against `--commits` when `--previous-tag` is given.** Every issue the CHANGELOG cites with `(#n)`
+  must be closed by a commit in `<prevTag>..HEAD` (a `Fixes #n` / `Closes #n` / … trailer, or the same `#n` on the
+  squash suffix), and every commit that closes an issue must be cited by the CHANGELOG. A mismatch is exit 2, one
+  line per problem; `--allow-unlinked` ships anyway with the mismatches as warnings. This is the same rule the
+  release script's `issue refs` preflight gate checks before the version bump — see
+  `.claude/skills/github-triage/SKILL.md` for the contract every fix has to leave behind, and §4 of
+  `docs/guide/releasing-wavee.md` for the gate. `commits`, `unlinkedCommits` and an index entry's `issues` (see the
+  table above) are how the result reaches the emitted document — none of that is authored here.
 
 ## Media
 

--- a/src/apps/Wavee.Core/ReleaseNotes/ReleaseCommits.cs
+++ b/src/apps/Wavee.Core/ReleaseNotes/ReleaseCommits.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Wavee.Core.ReleaseNotes;
+
+/// <summary>
+/// Cross-checks the CHANGELOG entry's <c>(#n)</c> refs against the commits actually shipped in
+/// <c>&lt;prevTag&gt;..HEAD</c> (git closing keywords are the source of truth for "this fixed an issue"; the
+/// CHANGELOG is the source of truth for "this shipped in this release"), and wires the two together for
+/// rendering (<see cref="ReleaseNotesValidation.RenderBody"/>).
+/// </summary>
+public static class ReleaseCommits
+{
+    /// <summary><c>commits.json</c> (the shape <c>ConvertFrom-GitLogRecords</c> / <c>Write-ReleaseCommitsJson</c>
+    /// write) → <see cref="ReleaseCommit"/>[]. Repairs null members, derives <see cref="ReleaseCommit.Short"/>
+    /// from <see cref="ReleaseCommit.Sha"/> when empty, and drops null array elements.</summary>
+    /// <exception cref="JsonException">The document is not a JSON array, or a commit has no <c>sha</c>.</exception>
+    public static ReleaseCommit[] Parse(ReadOnlySpan<byte> json)
+    {
+        var commits = JsonSerializer.Deserialize(json, ReleaseNotesJsonContext.Default.ReleaseCommitArray)
+            ?? throw new JsonException("commits.json is not an array");
+
+        var list = new List<ReleaseCommit>(commits.Length);
+        foreach (var c in commits)
+        {
+            if (c is null) continue;
+            if (string.IsNullOrEmpty(c.Sha)) throw new JsonException("a commit in commits.json has no sha");
+            c.Short = string.IsNullOrEmpty(c.Short) ? c.Sha[..Math.Min(7, c.Sha.Length)] : c.Short;
+            c.Subject ??= "";
+            c.Issues ??= [];
+            c.Prs ??= [];
+            list.Add(c);
+        }
+        return list.ToArray();
+    }
+
+    /// <summary>
+    /// ALWAYS attaches <paramref name="commits"/> to every section item whose <c>#n</c>/<c>!n</c> refs intersect
+    /// the commit's issues∪prs (dedup by sha), fills <see cref="ReleaseNotesDocument.UnlinkedCommits"/> (commits
+    /// matching no item, in input order), and returns the mismatches between the CHANGELOG entry's refs and the
+    /// commits' closing keywords — one line per issue number, ascending:
+    /// <code>
+    /// issue #{n} is fixed by {short} "{subject}" but the CHANGELOG [{doc.Version}] entry does not cite it
+    /// CHANGELOG cites #{n} but no commit in {range} carries "Fixes #{n}"
+    /// </code>
+    /// Only closing-keyword issues (<see cref="ReleaseCommit.Issues"/>) can be "missing in the changelog"; a
+    /// CHANGELOG <c>#n</c> is satisfied by a commit whose <see cref="ReleaseCommit.Issues"/> OR
+    /// <see cref="ReleaseCommit.Prs"/> contain <c>n</c>. Issue refs of another repo
+    /// (<see cref="ReleaseIssue.Repo"/> set and different from <paramref name="repo"/>, case-insensitive) are
+    /// ignored. Calls <see cref="ReleaseNotesDocument.Normalize"/> first. Errors are returned even when attaching
+    /// (so <c>--allow-unlinked</c> can ship what it has).
+    /// </summary>
+    public static IReadOnlyList<string> Link(
+        ReleaseNotesDocument doc, IReadOnlyList<ReleaseCommit> commits, string repo, string range)
+    {
+        ArgumentNullException.ThrowIfNull(doc);
+        ArgumentNullException.ThrowIfNull(commits);
+        doc.Normalize();
+
+        // Every item's own ref numbers (issues, repo-filtered, ∪ PRs), and which items own a given ref number.
+        var itemsByRef = new Dictionary<int, List<ReleaseItem>>();
+        var changelogIssues = new SortedSet<int>();
+        foreach (var section in doc.Sections)
+        {
+            foreach (var item in section.Items)
+            {
+                var refs = new HashSet<int>();
+                foreach (var i in item.Issues)
+                {
+                    if (i.Repo.Length > 0 && !string.Equals(i.Repo, repo, StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    refs.Add(i.Number);
+                    changelogIssues.Add(i.Number);
+                }
+                foreach (var p in item.Prs) refs.Add(p.Number);
+
+                foreach (var n in refs)
+                {
+                    if (!itemsByRef.TryGetValue(n, out var list)) itemsByRef[n] = list = [];
+                    list.Add(item);
+                }
+            }
+        }
+
+        // Attach: for each commit, find every item whose refs intersect this commit's issues∪prs.
+        var itemCommits = new Dictionary<ReleaseItem, (HashSet<string> Shas, List<ReleaseCommit> Commits)>();
+        var unlinked = new List<ReleaseCommit>();
+        var refSatisfied = new HashSet<int>();
+        var fixedBy = new Dictionary<int, List<ReleaseCommit>>();
+
+        foreach (var c in commits)
+        {
+            var commitRefs = new HashSet<int>();
+            foreach (var n in c.Issues)
+            {
+                commitRefs.Add(n);
+                refSatisfied.Add(n);
+                if (!fixedBy.TryGetValue(n, out var fixers)) fixedBy[n] = fixers = [];
+                fixers.Add(c);
+            }
+            foreach (var n in c.Prs)
+            {
+                commitRefs.Add(n);
+                refSatisfied.Add(n);
+            }
+
+            var touched = new HashSet<ReleaseItem>();
+            foreach (var n in commitRefs)
+                if (itemsByRef.TryGetValue(n, out var list))
+                    foreach (var item in list) touched.Add(item);
+
+            foreach (var item in touched)
+            {
+                if (!itemCommits.TryGetValue(item, out var bucket))
+                    itemCommits[item] = bucket = ([], []);
+                if (bucket.Shas.Add(c.Sha)) bucket.Commits.Add(c);
+            }
+            if (touched.Count == 0) unlinked.Add(c);
+        }
+
+        foreach (var section in doc.Sections)
+            foreach (var item in section.Items)
+                item.Commits = itemCommits.TryGetValue(item, out var bucket) ? [.. bucket.Commits] : [];
+        doc.UnlinkedCommits = [.. unlinked];
+
+        var mismatches = new List<(int Issue, string Message)>();
+        foreach (var (n, fixers) in fixedBy)
+        {
+            if (changelogIssues.Contains(n)) continue;
+            var first = fixers[0];
+            mismatches.Add((n,
+                $"issue #{n} is fixed by {first.Short} \"{first.Subject}\" but the CHANGELOG [{doc.Version}] entry does not cite it"));
+        }
+        foreach (var n in changelogIssues)
+        {
+            if (refSatisfied.Contains(n)) continue;
+            mismatches.Add((n, $"CHANGELOG cites #{n} but no commit in {range} carries \"Fixes #{n}\""));
+        }
+        mismatches.Sort((a, b) => a.Issue.CompareTo(b.Issue));
+
+        var errors = new List<string>(mismatches.Count);
+        foreach (var m in mismatches) errors.Add(m.Message);
+        return errors;
+    }
+}

--- a/src/apps/Wavee.Core/ReleaseNotes/ReleaseNotesDocument.cs
+++ b/src/apps/Wavee.Core/ReleaseNotes/ReleaseNotesDocument.cs
@@ -33,6 +33,8 @@ public sealed class ReleaseNotesDocument
     /// <summary>Issue-state snapshot time — the page's "as of".</summary>
     public string GeneratedAt { get; set; } = "";
     public ReleaseMedia[] Media { get; set; } = [];
+    /// <summary>Commits in range that cite no section item's issue/PR — the "Other changes" appendix.</summary>
+    public ReleaseCommit[] UnlinkedCommits { get; set; } = [];
 
     /// <summary>
     /// Replace every <see langword="null"/> the wire could have put here with the empty value the rest of the code
@@ -93,6 +95,8 @@ public sealed class ReleaseNotesDocument
                 foreach (var p in item.Prs) { p.Repo ??= ""; p.Title ??= ""; }
                 item.Contributors = Compact(item.Contributors);
                 foreach (var c in item.Contributors) c.Login ??= "";
+                item.Commits = Compact(item.Commits);
+                foreach (var c in item.Commits) NormalizeCommit(c);
             }
         }
 
@@ -104,6 +108,20 @@ public sealed class ReleaseNotesDocument
 
         Media = Compact(Media);
         foreach (var m in Media) { m.Src ??= ""; m.Sha256 ??= ""; }
+
+        UnlinkedCommits = Compact(UnlinkedCommits);
+        foreach (var c in UnlinkedCommits) NormalizeCommit(c);
+    }
+
+    /// <summary>Repairs a <see cref="ReleaseCommit"/> read from the wire: null strings become <c>""</c>, null
+    /// arrays become <c>[]</c>.</summary>
+    static void NormalizeCommit(ReleaseCommit c)
+    {
+        c.Sha ??= "";
+        c.Short ??= "";
+        c.Subject ??= "";
+        c.Issues ??= [];
+        c.Prs ??= [];
     }
 
     /// <summary>A null array becomes empty, and a null ELEMENT inside one (<c>"sections": [null]</c> is legal JSON) is
@@ -172,6 +190,8 @@ public sealed class ReleaseItem
     public ReleaseIssue[] Issues { get; set; } = [];
     public ReleasePr[] Prs { get; set; } = [];
     public ReleaseContributor[] Contributors { get; set; } = [];
+    /// <summary>Commits (from <c>--commits</c>) whose issues/PRs intersect this item's <see cref="Issues"/>/<see cref="Prs"/>.</summary>
+    public ReleaseCommit[] Commits { get; set; } = [];
 }
 
 public sealed class ReleaseIssue
@@ -198,6 +218,22 @@ public sealed class ReleaseContributor
 {
     public string Login { get; set; } = "";
     public bool FirstTime { get; set; }
+}
+
+/// <summary>One commit in <c>&lt;prevTag&gt;..HEAD</c>, as written by the release script to <c>commits.json</c>
+/// and re-emitted on the wire so the app can link straight to it.</summary>
+public sealed class ReleaseCommit
+{
+    /// <summary>40 hex.</summary>
+    public string Sha { get; set; } = "";
+    /// <summary>7-12 hex; derived from <see cref="Sha"/> when absent.</summary>
+    public string Short { get; set; } = "";
+    /// <summary>Verbatim commit subject; escaped at render time.</summary>
+    public string Subject { get; set; } = "";
+    /// <summary>Issue numbers closed by a closing-keyword trailer (<c>Fixes #n</c>, etc.).</summary>
+    public int[] Issues { get; set; } = [];
+    /// <summary>PR numbers named by a squash suffix <c>(#N)</c> or a <c>!N</c> reference.</summary>
+    public int[] Prs { get; set; } = [];
 }
 
 public sealed class ReleaseNotice
@@ -249,4 +285,6 @@ public sealed class ReleaseNotesIndexEntry
     public string Date { get; set; } = "";
     /// <summary>stable | beta.</summary>
     public string Channel { get; set; } = "stable";
+    /// <summary>Distinct issue numbers this release resolved, ascending.</summary>
+    public int[] Issues { get; set; } = [];
 }

--- a/src/apps/Wavee.Core/ReleaseNotes/ReleaseNotesJsonContext.cs
+++ b/src/apps/Wavee.Core/ReleaseNotes/ReleaseNotesJsonContext.cs
@@ -14,6 +14,7 @@ namespace Wavee.Core.ReleaseNotes;
 [JsonSerializable(typeof(ReleaseNotesDocument))]
 [JsonSerializable(typeof(ReleaseNotesIndex))]
 [JsonSerializable(typeof(IssueStateCache))]
+[JsonSerializable(typeof(ReleaseCommit[]))]
 public partial class ReleaseNotesJsonContext : JsonSerializerContext
 {
 }

--- a/src/apps/Wavee.Core/ReleaseNotes/ReleaseNotesValidation.cs
+++ b/src/apps/Wavee.Core/ReleaseNotes/ReleaseNotesValidation.cs
@@ -226,6 +226,7 @@ public static class ReleaseNotesValidation
             Name = doc.Name,
             Date = doc.Date,
             Channel = doc.Channel,
+            Issues = IssueNumbers(doc),
         };
         var list = new List<ReleaseNotesIndexEntry>(MaxIndexEntries) { head };
         if (previous?.Releases is { } prev)
@@ -350,6 +351,9 @@ public static class ReleaseNotesValidation
             sb.Append('\n');
         }
 
+        AppendResolvedIssues(sb, doc, repo);
+        AppendOtherChanges(sb, doc, repo);
+
         sb.Append("---\n\n");
         var facts = new List<string>(5);
         if (doc.Date.Length > 0) facts.Add("Released " + doc.Date);
@@ -371,6 +375,137 @@ public static class ReleaseNotesValidation
         }
 
         return sb.ToString();
+    }
+
+    /// <summary>The <c>## Resolved issues</c> block: one line per distinct issue number (ascending) the document
+    /// cites, its title, the commits that fix it and any PR that shipped it. Omitted entirely when no section item
+    /// carries a commit (<see cref="ReleaseItem.Commits"/>).</summary>
+    static void AppendResolvedIssues(StringBuilder sb, ReleaseNotesDocument doc, string repo)
+    {
+        bool anyCommits = false;
+        foreach (var s in doc.Sections)
+        {
+            foreach (var item in s.Items)
+            {
+                if (item.Commits.Length == 0) continue;
+                anyCommits = true;
+                break;
+            }
+            if (anyCommits) break;
+        }
+        if (!anyCommits) return;
+
+        sb.Append("## Resolved issues\n\n");
+        foreach (var n in IssueNumbers(doc))
+        {
+            ReleaseIssue? issue = null;
+            var commits = new List<ReleaseCommit>();
+            var seenSha = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var s in doc.Sections)
+            {
+                foreach (var item in s.Items)
+                {
+                    bool cites = false;
+                    foreach (var i in item.Issues)
+                    {
+                        if (i.Number != n) continue;
+                        cites = true;
+                        issue ??= i;
+                    }
+                    if (!cites) continue;
+                    // An item can cite several issues; only the commits that name THIS one (closing keyword or
+                    // squash suffix) belong on its line.
+                    foreach (var c in item.Commits)
+                        if ((Array.IndexOf(c.Issues, n) >= 0 || Array.IndexOf(c.Prs, n) >= 0) && seenSha.Add(c.Sha))
+                            commits.Add(c);
+                }
+            }
+
+            sb.Append("- [#").Append(n).Append("](https://github.com/").Append(repo)
+              .Append(issue is { IsPullRequest: true } ? "/pull/" : "/issues/").Append(n).Append(')');
+            if (issue is { Title.Length: > 0 }) sb.Append(' ').Append(EscapeMarkdown(issue.Title));
+            sb.Append(" — ");
+            if (commits.Count == 0)
+            {
+                sb.Append("no linked commit");
+            }
+            else
+            {
+                for (int i = 0; i < commits.Count; i++)
+                {
+                    if (i > 0) sb.Append(", ");
+                    sb.Append('[').Append(commits[i].Short).Append("](https://github.com/").Append(repo)
+                      .Append("/commit/").Append(commits[i].Sha).Append(')');
+                }
+                var prs = new SortedSet<int>();
+                foreach (var c in commits)
+                    foreach (var p in c.Prs)
+                        if (p != n) prs.Add(p);
+                if (prs.Count > 0)
+                {
+                    sb.Append(" (PR ");
+                    bool first = true;
+                    foreach (var p in prs)
+                    {
+                        if (!first) sb.Append(", ");
+                        first = false;
+                        sb.Append('[').Append('#').Append(p).Append("](https://github.com/").Append(repo)
+                          .Append("/pull/").Append(p).Append(')');
+                    }
+                    sb.Append(')');
+                }
+            }
+            sb.Append('\n');
+        }
+        sb.Append('\n');
+    }
+
+    /// <summary>The folded <c>&lt;details&gt;Other changes&lt;/details&gt;</c> appendix — every commit in range
+    /// that cites no section item (<see cref="ReleaseNotesDocument.UnlinkedCommits"/>). Omitted when empty.</summary>
+    static void AppendOtherChanges(StringBuilder sb, ReleaseNotesDocument doc, string repo)
+    {
+        if (doc.UnlinkedCommits.Length == 0) return;
+        sb.Append("<details><summary>Other changes</summary>\n\n");
+        foreach (var c in doc.UnlinkedCommits)
+            sb.Append("- [").Append(c.Short).Append("](https://github.com/").Append(repo).Append("/commit/")
+              .Append(c.Sha).Append(") ").Append(EscapeMarkdown(c.Subject)).Append('\n');
+        sb.Append("\n</details>\n\n");
+    }
+
+    /// <summary>Backslash-escapes GitHub Flavored Markdown's special characters (<c>\ * _ ` [ ] &lt; &gt; ~ |</c>)
+    /// so a commit subject or issue title cannot break the release body's formatting. Deliberately leaves
+    /// <c>#</c> alone — GitHub autolinks <c>#52</c> in a subject to the issue/PR, and escaping it would break
+    /// that.</summary>
+    public static string EscapeMarkdown(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return s;
+        var sb = new StringBuilder(s.Length + 8);
+        foreach (var ch in s)
+        {
+            switch (ch)
+            {
+                case '\\': case '*': case '_': case '`': case '[': case ']':
+                case '<': case '>': case '~': case '|':
+                    sb.Append('\\');
+                    break;
+            }
+            sb.Append(ch);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>Distinct issue numbers (&gt; 0) cited by any section item, ascending.</summary>
+    public static int[] IssueNumbers(ReleaseNotesDocument doc)
+    {
+        ArgumentNullException.ThrowIfNull(doc);
+        var set = new SortedSet<int>();
+        foreach (var s in doc.Sections)
+            foreach (var item in s.Items)
+                foreach (var i in item.Issues)
+                    if (i.Number > 0) set.Add(i.Number);
+        var result = new int[set.Count];
+        set.CopyTo(result);
+        return result;
     }
 
     /// <summary>

--- a/src/apps/Wavee.ReleaseTool/Program.cs
+++ b/src/apps/Wavee.ReleaseTool/Program.cs
@@ -34,7 +34,7 @@ static class Program
                 {
                     var bad = a.UnknownKeys("semver", "quad", "codename", "channel", "changelog", "notes", "out",
                                             "repo", "previous-index", "previous-tag", "github-token",
-                                            "allow-unresolved");
+                                            "allow-unresolved", "commits", "allow-unlinked");
                     if (bad.Count > 0) { Console.Error.WriteLine("error: unknown option(s): " + string.Join(", ", bad)); PrintUsage(); return Validator.ExitUsage; }
                     return await Validator.RunAsync(a, cts.Token).ConfigureAwait(false);
                 }
@@ -129,6 +129,9 @@ static class Program
           --previous-index <file>   Optional. The whatsnew-index.json from the rolling feed release; this release
                                     is prepended to it (newest first, capped at 12).
           --previous-tag <tag>      Optional. Fills links.compare and generate-notes' previous_tag_name.
+          --commits <file>          Required with --previous-tag. The commits.json the script writes from
+                                    `git log <previous-tag>..HEAD` — cross-checked against the CHANGELOG's
+                                    (#n) refs; mismatches fail the release (see --allow-unlinked).
           --github-token <token>    Optional. Raises the issue-lookup rate limit and enables the commits and
                                     contributors appendix (POST /releases/generate-notes). Falls back to the
                                     GITHUB_TOKEN environment variable, which is how the release script passes it.
@@ -136,6 +139,9 @@ static class Program
           --allow-unresolved        Optional. Ship even though some referenced issue/PR could not be read from
                                     GitHub (throttled, forbidden, offline). By default that is exit 2: the
                                     authored title/state would otherwise be published as if it had been verified.
+          --allow-unlinked          Optional. Ship although git and CHANGELOG.md disagree about which issues were
+                                    fixed (a commit fixes an issue the CHANGELOG entry doesn't cite, or vice versa).
+                                    By default that is exit 2; mismatches ship as warnings instead.
 
         RENDER OPTIONS
           --notes <file|dir>        Required. An emitted whatsnew.json (or the folder holding one).
@@ -161,6 +167,6 @@ static class Program
             --semver 0.2.0 --quad 0.2.0.17 --codename Breaker --channel stable ^
             --changelog CHANGELOG.md --notes ops/release/wavee/0.2.0 ^
             --out artifacts/release/0.2.0/notes --repo christosk92/WaveeMusic ^
-            --previous-tag wavee-v0.1.2 --github-token $env:GITHUB_TOKEN
+            --previous-tag wavee-v0.1.2 --commits artifacts/release/0.2.0/commits.json --github-token $env:GITHUB_TOKEN
         """;
 }

--- a/src/apps/Wavee.ReleaseTool/Validator.cs
+++ b/src/apps/Wavee.ReleaseTool/Validator.cs
@@ -34,10 +34,12 @@ static class Validator
         string repo = a.Require("repo", missing);
         string? previousIndex = a.Get("previous-index");
         string? previousTag = a.Get("previous-tag");
+        string? commitsPath = a.Get("commits");
         // The orchestrator hands the token through the ENVIRONMENT so it never lands in a command line, a
         // transcript or release-state.json; --github-token stays for a hand run. An explicit flag wins.
         string? token = a.Get("github-token") ?? Environment.GetEnvironmentVariable("GITHUB_TOKEN");
         bool allowUnresolved = a.Flag("allow-unresolved");
+        bool allowUnlinked = a.Flag("allow-unlinked");
         if (missing.Count > 0)
         {
             Console.Error.WriteLine("error: missing required argument(s): " + string.Join(", ", missing));
@@ -47,6 +49,16 @@ static class Validator
         if (channel is not ("stable" or "beta"))
         {
             Console.Error.WriteLine("error: --channel must be 'stable' or 'beta' (got '" + channel + "')");
+            return ExitUsage;
+        }
+        if (previousTag is { Length: > 0 } && commitsPath is null)
+        {
+            Console.Error.WriteLine("error: --commits <file> is required when --previous-tag is given (the script writes <stage>\\commits.json from git log <previous-tag>..HEAD)");
+            return ExitUsage;
+        }
+        if (commitsPath is not null && !File.Exists(commitsPath))
+        {
+            Console.Error.WriteLine("error: commits not found: " + commitsPath);
             return ExitUsage;
         }
 
@@ -103,8 +115,33 @@ static class Validator
         errors.AddRange(ReleaseNotesValidation.ValidateMedia(doc, notesDir));
         errors.AddRange(ReleaseNotesValidation.ValidateDeepLinks(doc));
 
-        // ── GitHub snapshots ────────────────────────────────────────────────────────────────────────────────
+        // ── commits.json cross-check ────────────────────────────────────────────────────────────────────────
         DefaultRepos(doc, repo);
+        if (commitsPath is not null)
+        {
+            ReleaseCommit[] commits;
+            try
+            {
+                commits = ReleaseCommits.Parse(File.ReadAllBytes(commitsPath));
+            }
+            catch (JsonException ex)
+            {
+                Console.Error.WriteLine($"error: {commitsPath} is not a valid commits.json: {ex.Message}");
+                return ExitUsage;
+            }
+            string range = previousTag is { Length: > 0 } pt ? pt + "..HEAD" : "the release range";
+            if (commits.Length == 0)
+                warnings.Add($"{commitsPath} lists no commits ({range} is empty)");
+            var mismatches = ReleaseCommits.Link(doc, commits, repo, range);
+            foreach (var m in mismatches)
+                (allowUnlinked ? warnings : errors).Add(allowUnlinked ? m + " (shipping anyway: --allow-unlinked)" : m);
+        }
+        else
+        {
+            warnings.Add("no --commits: the CHANGELOG/commit cross-check is skipped and RELEASE_BODY.md gets no Resolved issues section");
+        }
+
+        // ── GitHub snapshots ────────────────────────────────────────────────────────────────────────────────
         using var gh = new GitHubApi(token, semver);
         if (!gh.Authenticated)
             warnings.Add("no token (--github-token / GITHUB_TOKEN): issue lookups are unauthenticated (60/hour) and generate-notes is skipped");
@@ -149,8 +186,15 @@ static class Validator
         Console.WriteLine($"ok: Wavee {semver} \"{codename}\" ({quad}, {channel}) -> {Path.GetFullPath(outDir)}");
         Console.WriteLine($"    whatsnew.json + whatsnew-index.json + RELEASE_BODY.md + store-listing.txt + {copied} media file(s)");
         int items = 0;
-        foreach (var s in doc.Sections) items += s.Items.Length;
-        Console.WriteLine($"    {doc.Highlights.Length} highlight(s), {doc.Sections.Length} section(s), {items} item(s); as of {doc.GeneratedAt}");
+        int linked = 0;
+        foreach (var s in doc.Sections)
+            foreach (var item in s.Items)
+            {
+                items++;
+                linked += item.Commits.Length;
+            }
+        Console.WriteLine($"    {doc.Highlights.Length} highlight(s), {doc.Sections.Length} section(s), {items} item(s); as of {doc.GeneratedAt}" +
+                           $"; {linked} linked commit(s), {doc.UnlinkedCommits.Length} other");
         return ExitOk;
     }
 

--- a/src/apps/Wavee.Tests/ReleaseNotes/ReleaseCommitsTests.cs
+++ b/src/apps/Wavee.Tests/ReleaseNotes/ReleaseCommitsTests.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using Wavee.Core.ReleaseNotes;
+using Xunit;
+
+namespace Wavee.Tests.ReleaseNotes;
+
+/// <summary>
+/// <see cref="ReleaseCommits"/> — the `commits.json` reader and the cross-check that attaches a commit to every
+/// changelog item whose issue/PR it names, fills <see cref="ReleaseNotesDocument.UnlinkedCommits"/>, and reports
+/// the two ways the CHANGELOG and the git range can disagree. Pure: no file system, no network.
+/// </summary>
+public sealed class ReleaseCommitsTests
+{
+    // 40-hex, so callers can slice a 7-char short SHA the same way the real tool does.
+    const string Sha1 = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"; // short: a1b2c3d
+    const string Sha2 = "9f8e7d6c5b4a392817069f5a4b3c2d1e0f9e8d76"; // short: 9f8e7d6
+    const string Repo = ChangelogParser.WaveeRepo;
+    const string Range = "wavee-v0.2.5..HEAD";
+
+    static byte[] Json(string s) => Encoding.UTF8.GetBytes(s);
+
+    // ── Parse ───────────────────────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_ReadsTheScriptShape()
+    {
+        var commits = ReleaseCommits.Parse(Json($$"""
+        [
+          { "sha": "{{Sha1}}", "short": "a1b2c3d", "subject": "audio: fix xrun logging (#48)", "issues": [48], "prs": [] },
+          { "sha": "{{Sha2}}", "short": "9f8e7d6", "subject": "docs: nothing to link", "issues": [], "prs": [52] }
+        ]
+        """));
+
+        Assert.Equal(2, commits.Length);
+        Assert.Equal(Sha1, commits[0].Sha);
+        Assert.Equal("a1b2c3d", commits[0].Short);
+        Assert.Equal("audio: fix xrun logging (#48)", commits[0].Subject);
+        Assert.Equal(new[] { 48 }, commits[0].Issues);
+        Assert.Empty(commits[0].Prs);
+        Assert.Equal(new[] { 52 }, commits[1].Prs);
+        Assert.Empty(commits[1].Issues);
+    }
+
+    [Fact]
+    public void Parse_RepairsNulls_AndDerivesShortFromSha()
+    {
+        var commits = ReleaseCommits.Parse(Json($$"""
+        [
+          null,
+          { "sha": "{{Sha1}}", "short": null, "subject": null, "issues": null, "prs": null }
+        ]
+        """));
+
+        // The null array element is dropped, not surfaced.
+        var c = Assert.Single(commits);
+        Assert.Equal(Sha1, c.Sha);
+        Assert.Equal("a1b2c3d", c.Short);   // derived from Sha since "short" was null
+        Assert.Equal("", c.Subject);
+        Assert.Empty(c.Issues);
+        Assert.Empty(c.Prs);
+    }
+
+    [Fact]
+    public void Parse_DerivesShortFromSha_WhenShortIsAnEmptyString()
+    {
+        var commits = ReleaseCommits.Parse(Json($$"""[ { "sha": "{{Sha1}}", "short": "" } ]"""));
+        Assert.Equal("a1b2c3d", Assert.Single(commits).Short);
+    }
+
+    [Fact]
+    public void Parse_RejectsACommitWithoutASha()
+    {
+        Assert.Throws<JsonException>(() => ReleaseCommits.Parse(Json("""[ { "subject": "no sha here" } ]""")));
+    }
+
+    [Fact]
+    public void Parse_RejectsANonArray()
+    {
+        Assert.Throws<JsonException>(() => ReleaseCommits.Parse(Json("""{ "sha": "not an array" }""")));
+    }
+
+    [Fact]
+    public void Parse_OfEmptyArray_IsEmpty()
+    {
+        Assert.Empty(ReleaseCommits.Parse(Json("[]")));
+    }
+
+    // ── Link — fixtures ─────────────────────────────────────────────────────────────────────────────────────
+
+    static ReleaseCommit Commit(string sha, string subject, int[]? issues = null, int[]? prs = null) => new()
+    {
+        Sha = sha,
+        Short = sha[..7],
+        Subject = subject,
+        Issues = issues ?? [],
+        Prs = prs ?? [],
+    };
+
+    static ReleaseItem Item(int? issue = null, int? pr = null, string repo = Repo, bool issueIsPr = false) => new()
+    {
+        Id = "added-0",
+        Text = "Some fix.",
+        Issues = issue is { } n ? [new ReleaseIssue { Repo = repo, Number = n, Title = "T" + n, IsPullRequest = issueIsPr }] : [],
+        Prs = pr is { } p ? [new ReleasePr { Repo = repo, Number = p, Title = "PR" + p }] : [],
+    };
+
+    static ReleaseNotesDocument Doc(params ReleaseItem[] items) => new()
+    {
+        Version = "0.2.6",
+        Sections = [new ReleaseSection { Kind = "fixed", Items = items }],
+    };
+
+    // ── Link — attaching ────────────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Link_AttachesACommitToEveryItemCitingOneOfItsIssues()
+    {
+        var doc = Doc(Item(issue: 48), Item(issue: 41));
+        var fixes48 = Commit(Sha1, "fix: xrun logging", issues: [48]);
+        var fixes41 = Commit(Sha2, "fix: audio output", issues: [41]);
+
+        var errors = ReleaseCommits.Link(doc, [fixes48, fixes41], Repo, Range);
+
+        Assert.Empty(errors);
+        var items = doc.Sections[0].Items;
+        Assert.Same(fixes48, Assert.Single(items[0].Commits));
+        Assert.Same(fixes41, Assert.Single(items[1].Commits));
+    }
+
+    [Fact]
+    public void Link_AttachesTheSameCommitToEveryMatchingItem_DedupedBySha()
+    {
+        var doc = Doc(Item(issue: 48), Item(pr: 48));
+        var commit = Commit(Sha1, "fix: shared ref", issues: [48], prs: [48]);
+
+        ReleaseCommits.Link(doc, [commit, commit], Repo, Range);
+
+        var items = doc.Sections[0].Items;
+        Assert.Single(items[0].Commits);
+        Assert.Single(items[1].Commits);
+    }
+
+    [Fact]
+    public void Link_TreatsAPrCitedWithHash_AsLinked()
+    {
+        // The CHANGELOG cites "#52" as an issue-shaped ref (per the trailing-group grammar), but the commit only
+        // names it as a PR (squash suffix / !N). ReleaseCommits.Link still treats that as satisfied.
+        var doc = Doc(Item(issue: 52));
+        var commit = Commit(Sha1, "chore: squash (#52)", issues: [], prs: [52]);
+
+        var errors = ReleaseCommits.Link(doc, [commit], Repo, Range);
+
+        Assert.Empty(errors);
+        Assert.Same(commit, Assert.Single(doc.Sections[0].Items[0].Commits));
+    }
+
+    [Fact]
+    public void Link_DoesNotDemandTheChangelogCitePrs()
+    {
+        // A commit whose only ref is a PR number is not itself a "closing keyword" issue, so its absence from any
+        // item's Issues does not produce a mismatch — it simply attaches wherever an item's Prs names it (or is
+        // otherwise unlinked; see below).
+        var doc = Doc(Item(pr: 52));
+        var commit = Commit(Sha1, "chore: squash (#52)", issues: [], prs: [52]);
+
+        var errors = ReleaseCommits.Link(doc, [commit], Repo, Range);
+
+        Assert.Empty(errors);
+        Assert.Same(commit, Assert.Single(doc.Sections[0].Items[0].Commits));
+    }
+
+    [Fact]
+    public void Link_IgnoresIssuesOfAnotherRepo()
+    {
+        var doc = Doc(Item(issue: 48, repo: "someone/else"));
+        var commit = Commit(Sha1, "fix: xrun logging", issues: [48]);
+
+        var errors = ReleaseCommits.Link(doc, [commit], Repo, Range);
+
+        // Not attached to the foreign-repo item; the commit is unlinked for THIS repo's purposes.
+        Assert.Empty(doc.Sections[0].Items[0].Commits);
+        Assert.Same(commit, Assert.Single(doc.UnlinkedCommits));
+        Assert.Contains(errors, e => e.Contains("#48") && e.Contains("does not cite it"));
+    }
+
+    [Fact]
+    public void Link_CollectsCommitsCitingNothing_AsUnlinked_InOrder()
+    {
+        var doc = Doc(Item(issue: 48));
+        var fixes48 = Commit(Sha1, "fix: xrun logging", issues: [48]);
+        var chore = Commit(Sha2, "chore: bump deps");
+
+        ReleaseCommits.Link(doc, [chore, fixes48], Repo, Range);
+
+        Assert.Equal([chore], doc.UnlinkedCommits);
+    }
+
+    // ── Link — mismatches ───────────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Link_ReportsAnIssueFixedInGitButAbsentFromTheChangelog()
+    {
+        var doc = Doc(Item());   // the entry cites nothing, so the only mismatch is git's #48
+        var commit = Commit(Sha1, "fix: xrun logging", issues: [48]);
+
+        var errors = ReleaseCommits.Link(doc, [commit], Repo, Range);
+
+        Assert.Equal(
+            ["issue #48 is fixed by a1b2c3d \"fix: xrun logging\" but the CHANGELOG [0.2.6] entry does not cite it"],
+            errors);
+    }
+
+    [Fact]
+    public void Link_ReportsAChangelogIssueNoCommitFixes()
+    {
+        var doc = Doc(Item(issue: 48));
+
+        var errors = ReleaseCommits.Link(doc, [], Repo, Range);
+
+        Assert.Equal(
+            [$"CHANGELOG cites #48 but no commit in {Range} carries \"Fixes #48\""],
+            errors);
+    }
+
+    [Fact]
+    public void Link_ListsEveryMismatchOnce_AscendingByIssue()
+    {
+        var doc = Doc(Item(issue: 90), Item(issue: 10));
+        var commit41 = Commit(Sha1, "fix: 41", issues: [41]);
+        var commit20 = Commit(Sha2, "fix: 20", issues: [20]);
+
+        var errors = ReleaseCommits.Link(doc, [commit41, commit20], Repo, Range);
+
+        // One line per issue number, globally ascending — missing-in-git and missing-in-changelog interleave by
+        // number rather than sorting as two separate groups: 10, 20, 41, 90.
+        Assert.Equal(
+        [
+            $"CHANGELOG cites #10 but no commit in {Range} carries \"Fixes #10\"",
+            "issue #20 is fixed by 9f8e7d6 \"fix: 20\" but the CHANGELOG [0.2.6] entry does not cite it",
+            "issue #41 is fixed by a1b2c3d \"fix: 41\" but the CHANGELOG [0.2.6] entry does not cite it",
+            $"CHANGELOG cites #90 but no commit in {Range} carries \"Fixes #90\"",
+        ], errors);
+    }
+
+    [Fact]
+    public void Link_StillAttaches_WhenItReportsErrors()
+    {
+        // --allow-unlinked ships what it has: attaching and reporting are independent, not either/or.
+        var doc = Doc(Item(issue: 48));
+        var commit = Commit(Sha1, "fix: xrun logging", issues: [48, 41]);
+
+        var errors = ReleaseCommits.Link(doc, [commit], Repo, Range);
+
+        Assert.NotEmpty(errors);
+        Assert.Same(commit, Assert.Single(doc.Sections[0].Items[0].Commits));
+    }
+}

--- a/src/apps/Wavee.Tests/ReleaseNotes/ReleaseNotesJsonTests.cs
+++ b/src/apps/Wavee.Tests/ReleaseNotes/ReleaseNotesJsonTests.cs
@@ -116,6 +116,62 @@ public class ReleaseNotesJsonTests
         Assert.DoesNotContain("\"scope\"", json);
     }
 
+    // ── commit linkage (ReleaseCommit) ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AnOldDocumentWithoutCommits_ReadsAsEmptyArrays()
+    {
+        // Example predates the commit-linkage fields entirely — no "commits" or "unlinkedCommits" anywhere in it.
+        var doc = Read(Example);
+        Assert.Empty(doc.UnlinkedCommits);
+        Assert.Empty(Assert.Single(Assert.Single(doc.Sections).Items).Commits);
+    }
+
+    [Fact]
+    public void Commits_RoundTrip_CamelCased()
+    {
+        var doc = new ReleaseNotesDocument
+        {
+            Version = "0.2.6",
+            UnlinkedCommits =
+            [
+                new ReleaseCommit { Sha = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0", Short = "a1b2c3d", Subject = "chore: bump" },
+            ],
+            Sections =
+            [
+                new ReleaseSection
+                {
+                    Kind = "fixed",
+                    Items =
+                    [
+                        new ReleaseItem
+                        {
+                            Id = "fixed-0",
+                            Text = "x",
+                            Commits = [new ReleaseCommit { Sha = "9f8e7d6c5b4a392817069f5a4b3c2d1e0f9e8d76", Short = "9f8e7d6", Subject = "fix: y", Issues = [412] }],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        string once = Write(doc);
+        Assert.Contains("\"commits\":", once);
+        Assert.Contains("\"unlinkedCommits\":", once);
+        Assert.Contains("\"short\":", once);
+        Assert.Equal(once, Write(Read(once)));
+    }
+
+    [Fact]
+    public void AnOldIndexEntryWithoutIssues_ReadsAsEmpty()
+    {
+        const string Json = """
+{ "schema": 1, "product": "wavee", "releases": [ { "version": "0.2.5", "packageVersion": "0.2.5.6", "name": "Old", "date": "2026-08-01", "channel": "stable" } ] }
+""";
+        var index = JsonSerializer.Deserialize(Json, ReleaseNotesJsonContext.Default.ReleaseNotesIndex)!;
+        Assert.Empty(index.Releases[0].Issues);
+    }
+
     // ── the index ───────────────────────────────────────────────────────────────────────────────────────────────────
 
     [Fact]

--- a/src/apps/Wavee.Tests/ReleaseNotes/ReleaseNotesNormalizeTests.cs
+++ b/src/apps/Wavee.Tests/ReleaseNotes/ReleaseNotesNormalizeTests.cs
@@ -150,6 +150,33 @@ public class ReleaseNotesNormalizeTests
     }
 
     [Fact]
+    public void CommitArrays_AreRepaired()
+    {
+        var doc = Parse("""
+        {
+          "version": "0.3.0",
+          "unlinkedCommits": [null, { "sha": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0", "short": null, "subject": null, "issues": null, "prs": null }],
+          "sections": [{ "kind": "fixed", "items": [{ "id": "f1", "text": "Fixed a thing", "commits": null }] }]
+        }
+        """);
+
+        doc.Normalize();
+
+        var commit = Assert.Single(doc.UnlinkedCommits);
+        Assert.Equal("a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0", commit.Sha);
+        Assert.Equal("", commit.Short);
+        Assert.Equal("", commit.Subject);
+        Assert.Empty(commit.Issues);
+        Assert.Empty(commit.Prs);
+
+        var item = Assert.Single(Assert.Single(doc.Sections).Items);
+        Assert.Empty(item.Commits);
+
+        string body = ReleaseNotesValidation.RenderBody(doc, "acme/widgets", generatedNotes: null);
+        Assert.Contains("Wavee 0.3.0", body);
+    }
+
+    [Fact]
     public void TheRenderers_SurviveADocumentThatWasAllNulls()
     {
         // The proof that matters: the two surfaces the release tool drives (the GitHub body and the store blurb) run

--- a/src/apps/Wavee.Tests/ReleaseNotes/ReleaseNotesValidationTests.cs
+++ b/src/apps/Wavee.Tests/ReleaseNotes/ReleaseNotesValidationTests.cs
@@ -391,6 +391,153 @@ public sealed class ReleaseNotesValidationTests
         Assert.Equal("Security", ReleaseNotesValidation.SectionTitle("security"));
     }
 
+    // ── resolved issues / other changes (issue ⇄ commit linkage) ──────────────────────────────────────────────
+    // BodyDoc() above stays commit-free on purpose (Generated_notes_are_folded_into_a_details_block_and_omitted_when_absent
+    // asserts DoesNotContain("<details>") against it) — every test in this block builds its own document instead.
+
+    const string LinkSha1 = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"; // short: a1b2c3d
+    const string LinkSha2 = "9f8e7d6c5b4a392817069f5a4b3c2d1e0f9e8d76"; // short: 9f8e7d6
+
+    /// <summary>A <see cref="BodyDoc"/> whose only section item cites issue #412 + PR #52 and carries the two
+    /// commits that fixed it — the shape <c>ReleaseCommits.Link</c> leaves behind on a healthy release.</summary>
+    static ReleaseNotesDocument LinkedBodyDoc()
+    {
+        var doc = BodyDoc();
+        doc.Sections =
+        [
+            new ReleaseSection
+            {
+                Kind = "fixed",
+                Items =
+                [
+                    new ReleaseItem
+                    {
+                        Text = "Add mix feature.",
+                        Issues =
+                        [
+                            new ReleaseIssue { Repo = "christosk92/WaveeMusic", Number = 412, Title = "Please add *mix* feature", State = "closed" },
+                        ],
+                        Prs = [new ReleasePr { Repo = "christosk92/WaveeMusic", Number = 52, Merged = true }],
+                        Commits =
+                        [
+                            new ReleaseCommit { Sha = LinkSha1, Short = "a1b2c3d", Subject = "fix: add mix feature", Issues = [412], Prs = [52] },
+                            new ReleaseCommit { Sha = LinkSha2, Short = "9f8e7d6", Subject = "fix: polish mix feature", Issues = [412], Prs = [52] },
+                        ],
+                    },
+                ],
+            },
+        ];
+        return doc;
+    }
+
+    [Fact]
+    public void Resolved_issues_lists_each_issue_once_with_its_commits_and_pr()
+    {
+        string body = ReleaseNotesValidation.RenderBody(LinkedBodyDoc(), "christosk92/WaveeMusic", null);
+        Assert.Contains("## Resolved issues", body);
+
+        const string Golden = "- [#412](https://github.com/christosk92/WaveeMusic/issues/412) Please add \\*mix\\* feature — "
+            + "[a1b2c3d](https://github.com/christosk92/WaveeMusic/commit/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0), "
+            + "[9f8e7d6](https://github.com/christosk92/WaveeMusic/commit/9f8e7d6c5b4a392817069f5a4b3c2d1e0f9e8d76) "
+            + "(PR [#52](https://github.com/christosk92/WaveeMusic/pull/52))\n";
+        Assert.Contains(Golden, body);
+
+        int issueIdx = body.IndexOf(Golden, StringComparison.Ordinal);
+        int footerIdx = body.IndexOf("---\n\n", StringComparison.Ordinal);
+        Assert.True(issueIdx >= 0, "golden Resolved-issues line not found");
+        Assert.True(footerIdx >= 0, "footer not found");
+        Assert.True(issueIdx < footerIdx, "Resolved issues must precede the footer");
+    }
+
+    [Fact]
+    public void Other_changes_folds_unlinked_commits_and_is_omitted_when_empty()
+    {
+        var doc = LinkedBodyDoc();
+        doc.UnlinkedCommits = [new ReleaseCommit { Sha = LinkSha1, Short = "a1b2c3d", Subject = "chore: bump dependencies" }];
+
+        string body = ReleaseNotesValidation.RenderBody(doc, "christosk92/WaveeMusic", null);
+        Assert.Contains("<details><summary>Other changes</summary>", body);
+        Assert.Contains(
+            "- [a1b2c3d](https://github.com/christosk92/WaveeMusic/commit/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0) chore: bump dependencies",
+            body);
+
+        doc.UnlinkedCommits = [];
+        Assert.DoesNotContain("Other changes", ReleaseNotesValidation.RenderBody(doc, "christosk92/WaveeMusic", null));
+    }
+
+    [Fact]
+    public void Resolved_issues_still_lists_an_issue_with_no_commit_when_allow_unlinked_shipped_it()
+    {
+        var doc = BodyDoc();
+        doc.Sections =
+        [
+            new ReleaseSection
+            {
+                Kind = "fixed",
+                Items =
+                [
+                    new ReleaseItem
+                    {
+                        Text = "Two issues, one commit.",
+                        Issues =
+                        [
+                            new ReleaseIssue { Repo = "christosk92/WaveeMusic", Number = 412, Title = "Has a commit", State = "closed" },
+                            new ReleaseIssue { Repo = "christosk92/WaveeMusic", Number = 413, Title = "Shipped unlinked", State = "closed" },
+                        ],
+                        Commits = [new ReleaseCommit { Sha = LinkSha1, Short = "a1b2c3d", Subject = "fix: 412", Issues = [412] }],
+                    },
+                ],
+            },
+        ];
+
+        string body = ReleaseNotesValidation.RenderBody(doc, "christosk92/WaveeMusic", null);
+        Assert.Contains(
+            "[#412](https://github.com/christosk92/WaveeMusic/issues/412) Has a commit — [a1b2c3d](https://github.com/christosk92/WaveeMusic/commit/"
+            + LinkSha1 + ")", body);
+        Assert.Contains(
+            "[#413](https://github.com/christosk92/WaveeMusic/issues/413) Shipped unlinked — no linked commit", body);
+    }
+
+    [Fact]
+    public void EscapeMarkdown_escapes_punctuation_but_keeps_hash_autolinks()
+    {
+        Assert.Equal(@"\\ \* \_ \` \[ \] \< \> \~ \|", ReleaseNotesValidation.EscapeMarkdown(@"\ * _ ` [ ] < > ~ |"));
+        Assert.Equal("(#52) still autolinks", ReleaseNotesValidation.EscapeMarkdown("(#52) still autolinks"));
+        Assert.Equal("Please add \\*mix\\* feature", ReleaseNotesValidation.EscapeMarkdown("Please add *mix* feature"));
+        Assert.Equal("plain text is untouched", ReleaseNotesValidation.EscapeMarkdown("plain text is untouched"));
+    }
+
+    [Fact]
+    public void The_index_entry_carries_the_distinct_issue_numbers_ascending()
+    {
+        var doc = BodyDoc();
+        doc.Sections =
+        [
+            new ReleaseSection
+            {
+                Kind = "fixed",
+                Items =
+                [
+                    new ReleaseItem { Text = "a", Issues = [new ReleaseIssue { Repo = "christosk92/WaveeMusic", Number = 90 }] },
+                    new ReleaseItem
+                    {
+                        Text = "b",
+                        Issues =
+                        [
+                            new ReleaseIssue { Repo = "christosk92/WaveeMusic", Number = 41 },
+                            new ReleaseIssue { Repo = "christosk92/WaveeMusic", Number = 90 }, // duplicate, distinct in the result
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        Assert.Equal(new[] { 41, 90 }, ReleaseNotesValidation.IssueNumbers(doc));
+
+        var merged = ReleaseNotesValidation.MergeIndex(null, doc);
+        Assert.Equal(new[] { 41, 90 }, merged.Releases[0].Issues);
+    }
+
     // ── store listing ───────────────────────────────────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

Every release now says what it fixed and how. The body gets a **Resolved issues** section (issue → linked commit SHAs + PR), an **Other changes** list of range commits without an issue, and a working compare link; after verify, a new phase 12 comments "Shipped in Wavee x.y.z (build …)" on each resolved issue with the commit links.

The protection is a two-way cross-check between git closing keywords (`Fixes #n` in `<prevTag>..HEAD`) and the trailing `(#n)` group on the CHANGELOG entry's bullets. It runs as the hard `issue refs` preflight gate in `wavee-release.ps1` (before anything is bumped) and again in `Wavee.ReleaseTool` via `--previous-tag`/`--commits`, which also knows the GitHub issue state. A soft `issue coverage` check warns about bullets that cite nothing.

The fix-time half is a contract in the `github-triage` skill, CLAUDE.md and CONTRIBUTING: an issue exists, the CHANGELOG bullet ends with `(#n)`, the commit body carries `Fixes #n`, and a squash suffix `(#N)` is always a PR.

Along the way the rehearsal hit two pre-existing `-NoNotes` bugs (BOM in the reused `whatsnew.json`; empty `version`); both fixed.

## How I verified it

- `dotnet test` — 7029 passed (17 new tests across `ReleaseCommitsTests`, validation, JSON and normalize suites).
- `Invoke-Pester -Path ops/release/tests` — 303 passed (33 new in `Wavee.ReleaseRefs.Tests.ps1`).
- `dotnet build Wavee.slnx` Debug and Release clean.
- `-DryRun -NoNotes -Force -NoSign -SkipArch x64` on a scratch branch with a `[0.2.6]` entry citing `(#41)` and a `Fixes #41` commit: gate row `1 issue(s) linked`, `RELEASE_BODY.md` renders the Resolved issues line with the fetched title and commit link, the comment is previewed. Dropping the `(#41)` and, separately, the `Fixes #41` trailer each fail preflight with the intended message.

## Checklist

- [x] Debug and Release build clean; `Wavee.Tests` green
- [x] No source-text tests; no env switches; no legacy paths kept
- [x] Nothing under the private PlayPlay paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vw6FPcZRDwq3syfbfKJPvu
